### PR TITLE
refactor(remove-butils): remove butils and cleanup type array

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ submit an Issue or even a PR.  Trust me, I don't take criticism personally, and 
     swapping which callback gets invoked on receipt of new data. (e.g. post-connection, we write the AMQP version header
     and then install a callback to ensure the correct version.  Once incoming data is written to the circular buffer, this
     callback is invoked, and a comparison vs. the expected version triggers another transition).
-+   Bit-twiddling is done via [node-butils](https://github.com/nlf/node-butils).
 +   Debug output is done via [debug](https://www.npmjs.com/package/debug) with the prefix `amqp10-`.  The main client's debug
     name is `amqp10-client` so setting `DEBUG=amqp10-client` will get you all top-level debugging output.
 

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -2,7 +2,6 @@
 
 var debug = require('debug')('amqp10-Codec'),
     util = require('util'),
-    butils = require('butils'),
     builder = require('buffer-builder'),
     Int64 = require('node-int64'),
 
@@ -106,7 +105,7 @@ Codec.prototype._readFullValue = function(buf, offset, doNotConsume, forcedCode)
     case 0xF0:
       if (remaining < 5) return false;
       codeAndLength = this._peek(buf, offset, codeBytes + 4);
-      numBytes = butils.readInt32(codeAndLength, codeBytes) + 4 + codeBytes; // code + size + #octets
+      numBytes = codeAndLength.readUInt32BE(codeBytes) + 4 + codeBytes; // code + size + #octets
       //debug('Reading variable with prefix 0x'+codePrefix.toString(16)+' of length '+numBytes);
       return remaining >= numBytes ? [reader(buf, offset, numBytes), numBytes] : undefined;
 

--- a/lib/frames/frame.js
+++ b/lib/frames/frame.js
@@ -2,7 +2,6 @@
 
 var debug = require('debug')('amqp10-Frame'),
     debugAMQP = require('debug')('amqp10-AMQPFrame'),
-    butils = require('butils'),
     builder = require('buffer-builder'),
     util = require('util'),
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var debug = require('debug')('amqp10-types'),
-    butils = require('butils'),
     builder = require('buffer-builder'),
     Int64 = require('node-int64'),
 
@@ -77,60 +76,60 @@ var Types = function() {
  * @param {Number} [width]      Should be 1 or 4.  If given, builder assumes code already written, and will ensure array is encoded to the given byte-width type.  Useful for arrays.
  * @private
  */
-Types.prototype._listBuilder = function(val, bufb, codec, width) {
-  if (typeof val === 'object') {
-    if (val instanceof Array) {
-      if (!width && val.length === 0) {
-        bufb.appendUInt8(0x45);
-      } else {
-        // Encode all elements into a temp buffer to allow us to front-load appropriate size and count.
-        var tempBuilder = new builder();
-        for (var idx in val) {
-          var curVal = val[idx];
-          codec.encode(curVal, tempBuilder);
-        }
-        var tempBuffer = tempBuilder.get();
-
-        // Code, size, length, data
-        if (width === 1 || (tempBuffer.length < 0xFF && val.length < 0xFF && width !== 4)) {
-          // Short lists
-          if (!width) bufb.appendUInt8(0xC0);
-          bufb.appendUInt8(tempBuffer.length + 1);
-          bufb.appendUInt8(val.length);
-        } else {
-          // Long lists
-          if (!width) bufb.appendUInt8(0xD0);
-          bufb.appendUInt32BE(tempBuffer.length + 4);
-          bufb.appendUInt32BE(val.length);
-        }
-        bufb.appendBuffer(tempBuffer);
-      }
-    } else {
-      throw new exceptions.EncodingError('Unsure how to encode non-array as list');
-    }
-  } else {
-    throw new exceptions.EncodingError('Unsure how to encode non-object as list');
+Types.prototype._listBuilder = function(list, bufb, codec, width) {
+  if (!Array.isArray(list)) {
+    throw new exceptions.EncodingError('Unsure how to encode non-array as list');
   }
+
+  if (!width && list.length === 0) {
+    bufb.appendUInt8(0x45);
+    return;
+  }
+
+  // Encode all elements into a temp buffer to allow us to front-load appropriate size and count.
+  var tempBuilder = new builder();
+  list.forEach(function(value) {
+    codec.encode(value, tempBuilder);
+  });
+
+  var tempBuffer = tempBuilder.get();
+
+  // Code, size, length, data
+  if (width === 1 || (tempBuffer.length < 0xFF && list.length < 0xFF && width !== 4)) {
+    // Short lists
+    if (!width) bufb.appendUInt8(0xC0);
+    bufb.appendUInt8(tempBuffer.length + 1);
+    bufb.appendUInt8(list.length);
+  } else {
+    // Long lists
+    if (!width) bufb.appendUInt8(0xD0);
+    bufb.appendUInt32BE(tempBuffer.length + 4);
+    bufb.appendUInt32BE(list.length);
+  }
+
+  bufb.appendBuffer(tempBuffer);
 };
 
-Types.prototype._listDecoder = function(countSize, buf, codec) {
+Types.prototype._listDecoder = function(countSize, buffer, codec) {
   var size = 0;
   var count = 0;
   if (countSize === 1) {
-    size = butils.readInt(buf, 0);
-    count = butils.readInt(buf, 1);
+    size = buffer.readUInt8(0);
+    count = buffer.readUInt8(1);
   } else {
-    size = butils.readInt32(buf, 0);
-    count = butils.readInt32(buf, countSize);
+    size = buffer.readUInt32BE(0);
+    count = buffer.readUInt32BE(countSize);
   }
+
   var offset = countSize * 2;
-  var decoded = codec.decode(buf, offset);
+  var decoded = codec.decode(buffer, offset);
   var result = [];
   while (decoded !== undefined) {
     result.push(decoded[0]);
     offset += decoded[1];
-    decoded = codec.decode(buf, offset);
+    decoded = codec.decode(buffer, offset);
   }
+
   return result;
 };
 
@@ -161,66 +160,69 @@ Types.prototype._listDecoder = function(countSize, buf, codec) {
  * @private
  */
 Types.prototype._arrayBuilder = function(val, bufb, codec, width) {
-  if (typeof val === 'object') {
-    if (val instanceof AMQPArray) {
-      if (!width && val.array.length === 0) {
-        bufb.appendUInt8(0x40); // null
-      } else {
-        var tempBufb = new builder();
-        var enc = this.buildersByCode[val.elementType];
-        if (!enc) {
-          throw new exceptions.EncodingError('Unable to encode AMQP Array for type: ' + val.elementType + '.  Type builder not found.');
-        }
-        for (var idx in val.array) {
-          var curElt = val.array[idx];
-          enc(curElt, tempBufb, codec);
-        }
-        var arrayBytes = tempBufb.get();
-        if (width === 1 || (width !== 4 && arrayBytes.length < 0xFF && val.array.length < 0xFF)) {
-          if (!width) bufb.appendUInt8(0xE0);
-          bufb.appendUInt8(arrayBytes.length + 1 + 1); // buffer + count + constructor
-          bufb.appendUInt8(val.array.length);
-        } else {
-          if (!width) bufb.appendUInt8(0xF0);
-          bufb.appendUInt32BE(arrayBytes.length + 4 + 1); // buffer + count + constructor
-          bufb.appendUInt32BE(val.array.length);
-        }
-        bufb.appendUInt8(val.elementType);
-        bufb.appendBuffer(arrayBytes);
-      }
-    } else {
-      throw new exceptions.EncodingError('Unsure how to encode non-amqp-array as array');
-    }
-  } else {
-    throw new exceptions.EncodingError('Unsure how to encode non-object as array');
+  if (!(val instanceof AMQPArray)) {
+    throw new exceptions.EncodingError('Unsure how to encode non-amqp-array as array');
   }
+
+  if (!width && val.array.length === 0) {
+    bufb.appendUInt8(0x40); // null
+    return;
+  }
+
+  var tempBufb = new builder();
+  var encode = this.buildersByCode[val.elementType];
+  if (!encode) {
+    throw new exceptions.EncodingError('Unable to encode AMQP Array for type: ' + val.elementType + '.  Type builder not found.');
+  }
+
+  val.array.forEach(function(element) {
+    encode(element, tempBufb, codec);
+  });
+
+  var arrayBytes = tempBufb.get();
+  if (width === 1 || (width !== 4 && arrayBytes.length < 0xFF && val.array.length < 0xFF)) {
+    if (!width) bufb.appendUInt8(0xE0);
+    bufb.appendUInt8(arrayBytes.length + 1 + 1); // buffer + count + constructor
+    bufb.appendUInt8(val.array.length);
+  } else {
+    if (!width) bufb.appendUInt8(0xF0);
+    bufb.appendUInt32BE(arrayBytes.length + 4 + 1); // buffer + count + constructor
+    bufb.appendUInt32BE(val.array.length);
+  }
+
+  bufb.appendUInt8(val.elementType);
+  bufb.appendBuffer(arrayBytes);
 };
 
-Types.prototype._arrayDecoder = function(countSize, buf, codec) {
+Types.prototype._arrayDecoder = function(countSize, buffer, codec) {
   var size = 0;
   var count = 0;
   if (countSize === 1) {
-    size = butils.readInt(buf, 0);
-    count = butils.readInt(buf, 1);
+    size = buffer.readUInt8(0);
+    count = buffer.readUInt8(1);
   } else {
-    size = butils.readInt32(buf, 0);
-    count = butils.readInt32(buf, countSize);
+    size = buffer.readUInt32BE(0);
+    count = buffer.readUInt32BE(countSize);
   }
+
   var offset = countSize * 2;
-  var elementType = butils.readInt(buf, offset++);
+  var elementType = buffer.readUInt8(offset++);
   var decoder = this.decoders[elementType];
   if (!decoder) {
     throw new exceptions.MalformedPayloadError('Unknown array element type ' + elementType.toString(16));
   }
+
   var result = [];
   for (var idx = 0; idx < count; ++idx) {
-    var decoded = codec.decode(buf, offset, elementType);
+    var decoded = codec.decode(buffer, offset, elementType);
     if (!decoded) {
-      throw new exceptions.MalformedPayloadError('Unable to decode value of ' + elementType.toString(16) + ' from buffer ' + buf.toString('hex') + ' at index ' + idx + ' of array');
+      throw new exceptions.MalformedPayloadError('Unable to decode value of ' + elementType.toString(16) + ' from buffer ' + buffer.toString('hex') + ' at index ' + idx + ' of array');
     }
+
     result.push(decoded[0]);
     offset += decoded[1];
   }
+
   return result;
 };
 
@@ -247,70 +249,76 @@ Types.prototype._arrayDecoder = function(countSize, buf, codec) {
  * @param {Number} [width]      Should be 1 or 4.  If given, builder assumes code already written, and will ensure array is encoded to the given byte-width type.  Useful for arrays.
  * @private
  */
-Types.prototype._mapBuilder = function(val, bufb, codec, width) {
-  if (typeof val === 'object') {
-    if (val instanceof Array) {
-      throw new exceptions.NotImplementedError('Unsure how to encode array as map');
-    } else {
-      var keys = Object.keys(val);
-      if (!width && keys.length === 0) {
-        bufb.appendUInt8(0xC1);
-        bufb.appendUInt8(1);
-        bufb.appendUInt8(0);
-      } else {
-        // Encode all elements into a temp buffer to allow us to front-load appropriate size and count.
-        var tempBuilder = new builder();
-        for (var idx in keys) {
-          var curKey = keys[idx];
-          var curVal = val[curKey];
-          codec.encode(curKey, tempBuilder);
-          codec.encode(curVal, tempBuilder);
-        }
-        var tempBuffer = tempBuilder.get();
-
-        // Code, size, length, data
-        if (width === 1 || (width !== 4 && tempBuffer.length < 0xFF && val.length < 0xFF)) {
-          // Short lists
-          if (!width) bufb.appendUInt8(0xC1);
-          bufb.appendUInt8(tempBuffer.length + 1);
-          bufb.appendUInt8(keys.length * 2);
-        } else {
-          // Long lists
-          if (!width) bufb.appendUInt8(0xD1);
-          bufb.appendUInt32BE(tempBuffer.length + 4);
-          bufb.appendUInt32BE(keys.length * 2);
-        }
-        bufb.appendBuffer(tempBuffer);
-      }
-    }
-  } else {
+Types.prototype._mapBuilder = function(map, bufb, codec, width) {
+  if (typeof map !== 'object') {
     throw new exceptions.NotImplementedError('Unsure how to encode non-object as array');
   }
+
+  if (Array.isArray(map)) {
+    throw new exceptions.NotImplementedError('Unsure how to encode array as map');
+  }
+
+
+  var keys = Object.keys(map);
+  if (!width && keys.length === 0) {
+    bufb.appendUInt8(0xC1);
+    bufb.appendUInt8(1);
+    bufb.appendUInt8(0);
+    return;
+  }
+
+  // Encode all elements into a temp buffer to allow us to front-load appropriate size and count.
+  var tempBuilder = new builder();
+  for (var idx in keys) {
+    var curKey = keys[idx];
+    var curVal = map[curKey];
+    codec.encode(curKey, tempBuilder);
+    codec.encode(curVal, tempBuilder);
+  }
+  var tempBuffer = tempBuilder.get();
+
+  // Code, size, length, data
+  if (width === 1 || (width !== 4 && tempBuffer.length < 0xFF && map.length < 0xFF)) {
+    // Short lists
+    if (!width) bufb.appendUInt8(0xC1);
+    bufb.appendUInt8(tempBuffer.length + 1);
+    bufb.appendUInt8(keys.length * 2);
+  } else {
+    // Long lists
+    if (!width) bufb.appendUInt8(0xD1);
+    bufb.appendUInt32BE(tempBuffer.length + 4);
+    bufb.appendUInt32BE(keys.length * 2);
+  }
+
+  bufb.appendBuffer(tempBuffer);
 };
 
-Types.prototype._mapDecoder = function(countSize, buf, codec) {
+Types.prototype._mapDecoder = function(countSize, buffer, codec) {
   var size = 0;
   var count = 0;
   if (countSize === 1) {
-    size = butils.readInt(buf, 0);
-    count = butils.readInt(buf, 1);
+    size = buffer.readUInt8(0);
+    count = buffer.readUInt8(1);
   } else {
-    size = butils.readInt32(buf, 0);
-    count = butils.readInt32(buf, countSize);
+    size = buffer.readUInt32BE(0);
+    count = buffer.readUInt32BE(countSize);
   }
+
   var offset = countSize * 2;
-  var decodedKey = codec.decode(buf, offset);
+  var decodedKey = codec.decode(buffer, offset);
   var decodedVal;
   var result = {};
   while (decodedKey !== undefined) {
     offset += decodedKey[1];
-    decodedVal = codec.decode(buf, offset);
+    decodedVal = codec.decode(buffer, offset);
+
     if (decodedVal !== undefined) {
       result[decodedKey[0]] = decodedVal[0];
       offset += decodedVal[1];
-      decodedKey = codec.decode(buf, offset);
+      decodedKey = codec.decode(buffer, offset);
     }
   }
+
   return result;
 };
 
@@ -324,96 +332,96 @@ Types.prototype._initTypesArray = function() {
   var self = this;
   this.typesArray = [
     {
-      'class': 'primitive',
-      'name': 'null',
-      'label': 'indicates an empty value',
-      'builder': function(val, bufb) { bufb.appendUInt8(0x40); },
-      'encodings': [
+      class: 'primitive',
+      name: 'null',
+      label: 'indicates an empty value',
+      builder: function(val, bufb) { bufb.appendUInt8(0x40); },
+      encodings: [
         {
-          'code': '0x40',
-          'category': 'fixed',
-          'width': '0',
-          'label': 'the null value',
-          'builder': function(val, bufb) { },
-          'decoder': function(buf) { return null; }
+          code: 0x40,
+          category: 'fixed',
+          width: 0,
+          label: 'the null value',
+          builder: function(val, bufb) { },
+          decoder: function(buf) { return null; }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'boolean',
-      'label': 'represents a true or false value',
-      'builder': function(val, bufb) { bufb.appendUInt8(val ? 0x41 : 0x42); },
-      'encodings': [
+      class: 'primitive',
+      name: 'boolean',
+      label: 'represents a true or false value',
+      builder: function(val, bufb) { bufb.appendUInt8(val ? 0x41 : 0x42); },
+      encodings: [
         {
-          'code': '0x56',
-          'category': 'fixed',
-          'width': '1',
-          'label': 'boolean with the octet 0x00 being false and octet 0x01 being true',
-          'builder': function(val, bufb) { bufb.appendUInt8(val ? 0x01 : 0x00); },
-          'decoder': function(buf) { return buf[0] ? true : false; }
+          code: 0x56,
+          category: 'fixed',
+          width: 1,
+          label: 'boolean with the octet 0x00 being false and octet 0x01 being true',
+          builder: function(val, bufb) { bufb.appendUInt8(val ? 0x01 : 0x00); },
+          decoder: function(buf) { return buf[0] ? true : false; }
         },
         {
-          'code': '0x41',
-          'category': 'fixed',
-          'width': '0',
-          'label': 'the boolean value true',
-          'builder': function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
-          'decoder': function(buf) { return true; }
+          code: 0x41,
+          category: 'fixed',
+          width: 0,
+          label: 'the boolean value true',
+          builder: function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
+          decoder: function(buf) { return true; }
         },
         {
-          'code': '0x42',
-          'category': 'fixed',
-          'width': '0',
-          'label': 'the boolean value false',
-          'builder': function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
-          'decoder': function(buf) { return false; }
+          code: 0x42,
+          category: 'fixed',
+          width: 0,
+          label: 'the boolean value false',
+          builder: function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
+          decoder: function(buf) { return false; }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'ubyte',
-      'label': 'integer in the range 0 to 2^8 - 1 inclusive',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'ubyte',
+      label: 'integer in the range 0 to 2^8 - 1 inclusive',
+      builder: function(val, bufb) {
         bufb.appendUInt8(0x50);
         bufb.appendUInt8(val);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x50',
-          'category': 'fixed',
-          'width': '1',
-          'label': '8-bit unsigned integer',
-          'builder': function(val, bufb) { bufb.appendUInt8(val); },
-          'decoder': function(buf) { return buf[0]; }
+          code: 0x50,
+          category: 'fixed',
+          width: 1,
+          label: '8-bit unsigned integer',
+          builder: function(val, bufb) { bufb.appendUInt8(val); },
+          decoder: function(buf) { return buf[0]; }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'ushort',
-      'label': 'integer in the range 0 to 2^16 - 1 inclusive',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'ushort',
+      label: 'integer in the range 0 to 2^16 - 1 inclusive',
+      builder: function(val, bufb) {
         bufb.appendUInt8(0x60);
         bufb.appendUInt16BE(val);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x60',
-          'category': 'fixed',
-          'width': '2',
-          'label': '16-bit unsigned integer in network byte order',
-          'builder': function(val, bufb) { bufb.appendUInt16BE(val); },
-          'decoder': function(buf) { return buf.readUInt16BE(0); }
+          code: 0x60,
+          category: 'fixed',
+          width: 2,
+          label: '16-bit unsigned integer in network byte order',
+          builder: function(val, bufb) { bufb.appendUInt16BE(val); },
+          decoder: function(buf) { return buf.readUInt16BE(0); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'uint',
-      'label': 'integer in the range 0 to 2^32 - 1 inclusive',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'uint',
+      label: 'integer in the range 0 to 2^32 - 1 inclusive',
+      builder: function(val, bufb) {
         if (val === 0) {
           bufb.appendUInt8(0x43);
         } else if (val < 0xFF) {
@@ -424,38 +432,38 @@ Types.prototype._initTypesArray = function() {
           bufb.appendUInt32BE(val);
         }
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x70',
-          'category': 'fixed',
-          'width': '4',
-          'label': '32-bit unsigned integer in network byte order',
-          'builder': function(val, bufb) { bufb.appendUInt32BE(val); },
-          'decoder': function(buf) { return butils.readInt32(buf, 0); }
+          code: 0x70,
+          category: 'fixed',
+          width: 4,
+          label: '32-bit unsigned integer in network byte order',
+          builder: function(val, bufb) { bufb.appendUInt32BE(val); },
+          decoder: function(buf) { return buf.readUInt32BE(0); }
         },
         {
-          'code': '0x52',
-          'category': 'fixed',
-          'width': '1',
-          'label': 'unsigned integer value in the range 0 to 255 inclusive',
-          'builder': function(val, bufb) { bufb.appendUInt8(val); },
-          'decoder': function(buf) { return buf[0]; }
+          code: 0x52,
+          category: 'fixed',
+          width: 1,
+          label: 'unsigned integer value in the range 0 to 255 inclusive',
+          builder: function(val, bufb) { bufb.appendUInt8(val); },
+          decoder: function(buf) { return buf[0]; }
         },
         {
-          'code': '0x43',
-          'category': 'fixed',
-          'width': '0',
-          'label': 'the uint value 0',
-          'builder': function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
-          'decoder': function(buf) { return 0; }
+          code: 0x43,
+          category: 'fixed',
+          width: 0,
+          label: 'the uint value 0',
+          builder: function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
+          decoder: function(buf) { return 0; }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'ulong',
-      'label': 'integer in the range 0 to 2^64 - 1 inclusive',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'ulong',
+      label: 'integer in the range 0 to 2^64 - 1 inclusive',
+      builder: function(val, bufb) {
         if (val instanceof Int64 || val > 0xFF) {
           bufb.appendUInt8(0x80);
           self.buildersByCode[0x80](val, bufb);
@@ -468,13 +476,13 @@ Types.prototype._initTypesArray = function() {
           throw new Error('Invalid encoding type for 64-bit ulong value: ' + val);
         }
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x80',
-          'category': 'fixed',
-          'width': '8',
-          'label': '64-bit unsigned integer in network byte order',
-          'builder': function(val, bufb) {
+          code: 0x80,
+          category: 'fixed',
+          width: 8,
+          label: '64-bit unsigned integer in network byte order',
+          builder: function(val, bufb) {
             if (val instanceof Int64) {
               bufb.appendBuffer(val.toBuffer(true));
             } else if (typeof val === 'number') {
@@ -488,106 +496,106 @@ Types.prototype._initTypesArray = function() {
               throw new Error('Invalid encoding type for 64-bit value: ' + val);
             }
           },
-          'decoder': function(buf) { return new Int64(buf); }
+          decoder: function(buf) { return new Int64(buf); }
         },
         {
-          'code': '0x53',
-          'category': 'fixed',
-          'width': '1',
-          'label': 'unsigned long value in the range 0 to 255 inclusive',
-          'builder': function(val, bufb) { bufb.appendUInt8(val); },
-          'decoder': function(buf) { return new Int64(0x0, butils.readInt(buf, 0)); }
+          code: 0x53,
+          category: 'fixed',
+          width: 1,
+          label: 'unsigned long value in the range 0 to 255 inclusive',
+          builder: function(val, bufb) { bufb.appendUInt8(val); },
+          decoder: function(buf) { return new Int64(0x0, buf.readUInt8(0)); }
         },
         {
-          'code': '0x44',
-          'category': 'fixed',
-          'width': '0',
-          'label': 'the ulong value 0',
-          'builder': function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
-          'decoder': function(buf) { return new Int64(0, 0); }
+          code: 0x44,
+          category: 'fixed',
+          width: 0,
+          label: 'the ulong value 0',
+          builder: function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
+          decoder: function(buf) { return new Int64(0, 0); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'byte',
-      'label': 'integer in the range -(2^7) to 2^7 - 1 inclusive',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'byte',
+      label: 'integer in the range -(2^7) to 2^7 - 1 inclusive',
+      builder: function(val, bufb) {
         bufb.appendUInt8(0x51);
         bufb.appendInt8(val);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x51',
-          'category': 'fixed',
-          'width': '1',
-          'label': "8-bit two's-complement integer",
-          'builder': function(val, bufb) { bufb.appendInt8(val); },
-          'decoder': function(buf) { return buf.readInt8(0); }
+          code: 0x51,
+          category: 'fixed',
+          width: 1,
+          label: "8-bit two's-complement integer",
+          builder: function(val, bufb) { bufb.appendInt8(val); },
+          decoder: function(buf) { return buf.readInt8(0); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'short',
-      'label': 'integer in the range -(2^15) to 2^15 - 1 inclusive',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'short',
+      label: 'integer in the range -(2^15) to 2^15 - 1 inclusive',
+      builder: function(val, bufb) {
         bufb.appendUInt8(0x61);
         bufb.appendInt16BE(val);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x61',
-          'category': 'fixed',
-          'width': '2',
-          'label': "16-bit two's-complement integer in network byte order",
-          'builder': function(val, bufb) { bufb.appendInt16BE(val); },
-          'decoder': function(buf) { return buf.readInt16BE(0); }
+          code: 0x61,
+          category: 'fixed',
+          width: 2,
+          label: "16-bit two's-complement integer in network byte order",
+          builder: function(val, bufb) { bufb.appendInt16BE(val); },
+          decoder: function(buf) { return buf.readInt16BE(0); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'int',
-      'label': 'integer in the range -(2^31) to 2^31 - 1 inclusive',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'int',
+      label: 'integer in the range -(2^31) to 2^31 - 1 inclusive',
+      builder: function(val, bufb) {
         bufb.appendUInt8(0x71);
         bufb.appendInt32BE(val);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x71',
-          'category': 'fixed',
-          'width': '4',
-          'label': "32-bit two's-complement integer in network byte order",
-          'builder': function(val, bufb) { bufb.appendInt32BE(val); },
-          'decoder': function(buf) { return buf.readInt32BE(0); }
+          code: 0x71,
+          category: 'fixed',
+          width: 4,
+          label: "32-bit two's-complement integer in network byte order",
+          builder: function(val, bufb) { bufb.appendInt32BE(val); },
+          decoder: function(buf) { return buf.readInt32BE(0); }
         },
         {
-          'code': '0x54',
-          'category': 'fixed',
-          'width': '1',
-          'label': 'signed integer value in the range -128 to 127 inclusive',
-          'builder': function(val, bufb) { bufb.appendInt8(val); },
-          'decoder': function(buf) { return buf.readInt8(0); }
+          code: 0x54,
+          category: 'fixed',
+          width: 1,
+          label: 'signed integer value in the range -128 to 127 inclusive',
+          builder: function(val, bufb) { bufb.appendInt8(val); },
+          decoder: function(buf) { return buf.readInt8(0); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'long',
-      'label': 'integer in the range -(2^63) to 2^63 - 1 inclusive',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'long',
+      label: 'integer in the range -(2^63) to 2^63 - 1 inclusive',
+      builder: function(val, bufb) {
         bufb.appendUInt8(0x81);
         self.buildersByCode[0x81](val, bufb); // @todo Deal with Math.abs(val) < 0x7F cases
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x81',
-          'category': 'fixed',
-          'width': '8',
-          'label': "64-bit two's-complement integer in network byte order",
-          'builder': function(val, bufb) {
+          code: 0x81,
+          category: 'fixed',
+          width: 8,
+          label: "64-bit two's-complement integer in network byte order",
+          builder: function(val, bufb) {
             if (val instanceof Int64) {
               bufb.appendBuffer(val.toBuffer(true));
             } else if (typeof val === 'number') {
@@ -602,159 +610,159 @@ Types.prototype._initTypesArray = function() {
               throw new Error('Invalid encoding type for 64-bit value: ' + val);
             }
           },
-          'decoder': function(buf) { return new Int64(buf); }
+          decoder: function(buf) { return new Int64(buf); }
         },
         {
-          'code': '0x55',
-          'category': 'fixed',
-          'width': '1',
-          'label': 'signed long value in the range -128 to 127 inclusive',
-          'builder': function(val, bufb) { bufb.appendInt8(val); },
-          'decoder': function(buf) { return buf.readInt8(0); }
+          code: 0x55,
+          category: 'fixed',
+          width: 1,
+          label: 'signed long value in the range -128 to 127 inclusive',
+          builder: function(val, bufb) { bufb.appendInt8(val); },
+          decoder: function(buf) { return buf.readInt8(0); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'float',
-      'label': '32-bit floating point number (IEEE 754-2008 binary32)',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'float',
+      label: '32-bit floating point number (IEEE 754-2008 binary32)',
+      builder: function(val, bufb) {
         bufb.appendUInt8(0x72);
         bufb.appendFloatBE(val);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x72',
-          'category': 'fixed',
-          'width': '4',
-          'label': 'IEEE 754-2008 binary32',
-          'builder': function(val, bufb) { bufb.appendFloatBE(val); },
-          'decoder': function(buf) { return buf.readFloatBE(0); }
+          code: 0x72,
+          category: 'fixed',
+          width: 4,
+          label: 'IEEE 754-2008 binary32',
+          builder: function(val, bufb) { bufb.appendFloatBE(val); },
+          decoder: function(buf) { return buf.readFloatBE(0); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'double',
-      'label': '64-bit floating point number (IEEE 754-2008 binary64)',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'double',
+      label: '64-bit floating point number (IEEE 754-2008 binary64)',
+      builder: function(val, bufb) {
         bufb.appendUInt8(0x82);
         bufb.appendDoubleBE(val);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x82',
-          'category': 'fixed',
-          'width': '8',
-          'label': 'IEEE 754-2008 binary64',
-          'builder': function(val, bufb) { bufb.appendDoubleBE(val); },
-          'decoder': function(buf) { return buf.readDoubleBE(0); }
+          code: 0x82,
+          category: 'fixed',
+          width: 8,
+          label: 'IEEE 754-2008 binary64',
+          builder: function(val, bufb) { bufb.appendDoubleBE(val); },
+          decoder: function(buf) { return buf.readDoubleBE(0); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'decimal32',
-      'label': '32-bit decimal number (IEEE 754-2008 decimal32)',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'decimal32',
+      label: '32-bit decimal number (IEEE 754-2008 decimal32)',
+      builder: function(val, bufb) {
         throw new exceptions.NotImplementedError('Decimal32');
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x74',
-          'category': 'fixed',
-          'width': '4',
-          'label': 'IEEE 754-2008 decimal32 using the Binary Integer Decimal encoding',
-          'builder': function(val, bufb) {
+          code: 0x74,
+          category: 'fixed',
+          width: 4,
+          label: 'IEEE 754-2008 decimal32 using the Binary Integer Decimal encoding',
+          builder: function(val, bufb) {
             throw new exceptions.NotImplementedError('Decimal32');
           },
-          'decoder': function(buf) {
+          decoder: function(buf) {
             throw new exceptions.NotImplementedError('Decimal32');
           }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'decimal64',
-      'label': '64-bit decimal number (IEEE 754-2008 decimal64)',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'decimal64',
+      label: '64-bit decimal number (IEEE 754-2008 decimal64)',
+      builder: function(val, bufb) {
         throw new exceptions.NotImplementedError('Decimal64');
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x84',
-          'category': 'fixed',
-          'width': '8',
-          'label': 'IEEE 754-2008 decimal64 using the Binary Integer Decimal encoding',
-          'builder': function(val, bufb) {
+          code: 0x84,
+          category: 'fixed',
+          width: 8,
+          label: 'IEEE 754-2008 decimal64 using the Binary Integer Decimal encoding',
+          builder: function(val, bufb) {
             throw new exceptions.NotImplementedError('Decimal64');
           },
-          'decoder': function(buf) {
+          decoder: function(buf) {
             throw new exceptions.NotImplementedError('Decimal64');
           }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'decimal128',
-      'label': '128-bit decimal number (IEEE 754-2008 decimal128)',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'decimal128',
+      label: '128-bit decimal number (IEEE 754-2008 decimal128)',
+      builder: function(val, bufb) {
         throw new exceptions.NotImplementedError('Decimal128');
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x94',
-          'category': 'fixed',
-          'width': '16',
-          'label': 'IEEE 754-2008 decimal128 using the Binary Integer Decimal encoding',
-          'builder': function(val, bufb) {
+          code: 0x94,
+          category: 'fixed',
+          width: 16,
+          label: 'IEEE 754-2008 decimal128 using the Binary Integer Decimal encoding',
+          builder: function(val, bufb) {
             throw new exceptions.NotImplementedError('Decimal128');
           },
-          'decoder': function(buf) {
+          decoder: function(buf) {
             throw new exceptions.NotImplementedError('Decimal128');
           }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'char',
-      'label': 'a single unicode character',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'char',
+      label: 'a single unicode character',
+      builder: function(val, bufb) {
         throw new exceptions.NotImplementedError('UTF32');
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x73',
-          'category': 'fixed',
-          'width': '4',
-          'label': 'a UTF-32BE encoded unicode character',
-          'builder': function(val, bufb) {
+          code: 0x73,
+          category: 'fixed',
+          width: 4,
+          label: 'a UTF-32BE encoded unicode character',
+          builder: function(val, bufb) {
             throw new exceptions.NotImplementedError('UTF32');
           },
-          'decoder': function(buf) {
+          decoder: function(buf) {
             throw new exceptions.NotImplementedError('UTF32');
           }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'timestamp',
-      'label': 'an absolute point in time',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'timestamp',
+      label: 'an absolute point in time',
+      builder: function(val, bufb) {
         bufb.appendUInt8(0x83);
         self.buildersByCode[0x83](val, bufb);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x83',
-          'category': 'fixed',
-          'width': '8',
-          'label': '64-bit signed integer representing milliseconds since the unix epoch',
-          'builder': function(val, bufb) {
+          code: 0x83,
+          category: 'fixed',
+          width: 8,
+          label: '64-bit signed integer representing milliseconds since the unix epoch',
+          builder: function(val, bufb) {
             if (val instanceof Int64) {
               bufb.appendBuffer(val.toBuffer(true));
             } else if (typeof val === 'number') {
@@ -769,37 +777,37 @@ Types.prototype._initTypesArray = function() {
               throw new Error('Invalid encoding type for 64-bit value: ' + val);
             }
           },
-          'decoder': function(buf) { return new Int64(buf); }
+          decoder: function(buf) { return new Int64(buf); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'uuid',
-      'label': 'a universally unique id as defined by RFC-4122 section 4.1.2',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'uuid',
+      label: 'a universally unique id as defined by RFC-4122 section 4.1.2',
+      builder: function(val, bufb) {
         throw new exceptions.NotImplementedError('UUID');
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0x98',
-          'category': 'fixed',
-          'width': '16',
-          'label': 'UUID as defined in section 4.1.2 of RFC-4122',
-          'builder': function(val, bufb) {
+          code: 0x98,
+          category: 'fixed',
+          width: 16,
+          label: 'UUID as defined in section 4.1.2 of RFC-4122',
+          builder: function(val, bufb) {
             throw new exceptions.NotImplementedError('UUID');
           },
-          'decoder': function(buf) {
+          decoder: function(buf) {
             throw new exceptions.NotImplementedError('UUID');
           }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'binary',
-      'label': 'a sequence of octets',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'binary',
+      label: 'a sequence of octets',
+      builder: function(val, bufb) {
         if (val.length <= 0xFF) {
           bufb.appendUInt8(0xA0);
           bufb.appendUInt8(val.length);
@@ -809,38 +817,38 @@ Types.prototype._initTypesArray = function() {
         }
         bufb.appendBuffer(val);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0xa0',
-          'category': 'variable',
-          'width': '1',
-          'label': 'up to 2^8 - 1 octets of binary data',
-          'builder': function(val, bufb) {
+          code: 0xa0,
+          category: 'variable',
+          width: 1,
+          label: 'up to 2^8 - 1 octets of binary data',
+          builder: function(val, bufb) {
             bufb.appendUInt8(val.length);
             bufb.appendBuffer(val);
           },
-          'decoder': function(buf) {
+          decoder: function(buf) {
             return buf.slice(1);
           }
         },
         {
-          'code': '0xb0',
-          'category': 'variable',
-          'width': '4',
-          'label': 'up to 2^32 - 1 octets of binary data',
-          'builder': function(val, bufb) {
+          code: 0xb0,
+          category: 'variable',
+          width: 4,
+          label: 'up to 2^32 - 1 octets of binary data',
+          builder: function(val, bufb) {
             bufb.appendUInt32BE(val.length);
             bufb.appendBuffer(val);
           },
-          'decoder': function(buf) { return buf.slice(4); }
+          decoder: function(buf) { return buf.slice(4); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'string',
-      'label': 'a sequence of unicode characters',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'string',
+      label: 'a sequence of unicode characters',
+      builder: function(val, bufb) {
         var encoded = new Buffer(val, 'utf8');
         if (encoded.length <= 0xFF) {
           bufb.appendUInt8(0xA1);
@@ -851,33 +859,33 @@ Types.prototype._initTypesArray = function() {
         }
         bufb.appendBuffer(encoded);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0xa1',
-          'category': 'variable',
-          'width': '1',
-          'label': 'up to 2^8 - 1 octets worth of UTF-8 unicode (with no byte order mark)',
-          'builder': function(val, bufb) {
+          code: 0xa1,
+          category: 'variable',
+          width: 1,
+          label: 'up to 2^8 - 1 octets worth of UTF-8 unicode (with no byte order mark)',
+          builder: function(val, bufb) {
             var encoded = new Buffer(val, 'utf8');
             bufb.appendUInt8(encoded.length);
             bufb.appendBuffer(encoded);
           },
-          'decoder': function(buf) {
+          decoder: function(buf) {
             if (buf[0] === 0) return '';
             return buf.slice(1).toString('utf8');
           }
         },
         {
-          'code': '0xb1',
-          'category': 'variable',
-          'width': '4',
-          'label': 'up to 2^32 - 1 octets worth of UTF-8 unicode (with no byte order mark)',
-          'builder': function(val, bufb) {
+          code: 0xb1,
+          category: 'variable',
+          width: 4,
+          label: 'up to 2^32 - 1 octets worth of UTF-8 unicode (with no byte order mark)',
+          builder: function(val, bufb) {
             var encoded = new Buffer(val, 'utf8');
             bufb.appendUInt32BE(encoded.length);
             bufb.appendBuffer(encoded);
           },
-          'decoder': function(buf) {
+          decoder: function(buf) {
             var size = buf.readUInt32BE(0);
             if (size === 0) return '';
             return buf.slice(4).toString('utf8');
@@ -886,10 +894,10 @@ Types.prototype._initTypesArray = function() {
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'symbol',
-      'label': 'symbolic values from a constrained domain',
-      'builder': function(val, bufb) {
+      class: 'primitive',
+      name: 'symbol',
+      label: 'symbolic values from a constrained domain',
+      builder: function(val, bufb) {
         var encoded = new Buffer(val, 'utf8');
         if (encoded.length <= 0xFF) {
           bufb.appendUInt8(0xA3);
@@ -900,33 +908,33 @@ Types.prototype._initTypesArray = function() {
         }
         bufb.appendBuffer(encoded);
       },
-      'encodings': [
+      encodings: [
         {
-          'code': '0xa3',
-          'category': 'variable',
-          'width': '1',
-          'label': 'up to 2^8 - 1 seven bit ASCII characters representing a symbolic value',
-          'builder': function(val, bufb) {
+          code: 0xa3,
+          category: 'variable',
+          width: 1,
+          label: 'up to 2^8 - 1 seven bit ASCII characters representing a symbolic value',
+          builder: function(val, bufb) {
             var encoded = new Buffer(val, 'utf8');
             bufb.appendUInt8(encoded.length);
             bufb.appendBuffer(encoded);
           },
-          'decoder': function(buf) {
+          decoder: function(buf) {
             /** @todo Work with ASCII instead of UTF8 */
             return new AMQPSymbol(buf.slice(1).toString('utf8'));
           }
         },
         {
-          'code': '0xb3',
-          'category': 'variable',
-          'width': '4',
-          'label': 'up to 2^32 - 1 seven bit ASCII characters representing a symbolic value',
-          'builder': function(val, bufb) {
+          code: 0xb3,
+          category: 'variable',
+          width: 4,
+          label: 'up to 2^32 - 1 seven bit ASCII characters representing a symbolic value',
+          builder: function(val, bufb) {
             var encoded = new Buffer(val, 'utf8');
             bufb.appendUInt32BE(encoded.length);
             bufb.appendBuffer(encoded);
           },
-          'decoder': function(buf) {
+          decoder: function(buf) {
             /** @todo Work with ASCII instead of UTF8 */
             return new AMQPSymbol(buf.slice(4).toString('utf8'));
           }
@@ -934,82 +942,82 @@ Types.prototype._initTypesArray = function() {
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'list',
-      'label': 'a sequence of polymorphic values',
-      'builder': this._listBuilder,
-      'encodings': [
+      class: 'primitive',
+      name: 'list',
+      label: 'a sequence of polymorphic values',
+      builder: this._listBuilder,
+      encodings: [
         {
-          'code': '0x45',
-          'category': 'fixed',
-          'width': '0',
-          'label': 'the empty list (i.e. the list with no elements)',
-          'builder': function(val, bufb, codec) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
-          'decoder': function(buf) { return []; }
+          code: 0x45,
+          category: 'fixed',
+          width: 0,
+          label: 'the empty list (i.e. the list with no elements)',
+          builder: function(val, bufb, codec) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
+          decoder: function(buf) { return []; }
         },
         {
-          'code': '0xc0',
-          'category': 'compound',
-          'width': '1',
-          'label': 'up to 2^8 - 1 list elements with total size less than 2^8 octets',
-          'builder': function(val, bufb, codec) { self._listBuilder(val, bufb, codec, 1); },
-          'decoder': function(buf, codec) { return self._listDecoder(1, buf, codec); }
+          code: 0xc0,
+          category: 'compound',
+          width: 1,
+          label: 'up to 2^8 - 1 list elements with total size less than 2^8 octets',
+          builder: function(val, bufb, codec) { self._listBuilder(val, bufb, codec, 1); },
+          decoder: function(buf, codec) { return self._listDecoder(1, buf, codec); }
         },
         {
-          'code': '0xd0',
-          'category': 'compound',
-          'width': '4',
-          'label': 'up to 2^32 - 1 list elements with total size less than 2^32 octets',
-          'builder': function(val, bufb, codec) { self._listBuilder(val, bufb, codec, 4); },
-          'decoder': function(buf, codec) { return self._listDecoder(4, buf, codec); }
+          code: 0xd0,
+          category: 'compound',
+          width: 4,
+          label: 'up to 2^32 - 1 list elements with total size less than 2^32 octets',
+          builder: function(val, bufb, codec) { self._listBuilder(val, bufb, codec, 4); },
+          decoder: function(buf, codec) { return self._listDecoder(4, buf, codec); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'map',
-      'label': 'a polymorphic mapping from distinct keys to values',
-      'builder': this._mapBuilder,
-      'encodings': [
+      class: 'primitive',
+      name: 'map',
+      label: 'a polymorphic mapping from distinct keys to values',
+      builder: this._mapBuilder,
+      encodings: [
         {
-          'code': '0xc1',
-          'category': 'compound',
-          'width': '1',
-          'label': 'up to 2^8 - 1 octets of encoded map data',
-          'builder': function(val, bufb, codec) { self._mapBuilder(val, bufb, codec, 1); },
-          'decoder': function(buf, codec) { return self._mapDecoder(1, buf, codec); }
+          code: 0xc1,
+          category: 'compound',
+          width: 1,
+          label: 'up to 2^8 - 1 octets of encoded map data',
+          builder: function(val, bufb, codec) { self._mapBuilder(val, bufb, codec, 1); },
+          decoder: function(buf, codec) { return self._mapDecoder(1, buf, codec); }
         },
         {
-          'code': '0xd1',
-          'category': 'compound',
-          'width': '4',
-          'label': 'up to 2^32 - 1 octets of encoded map data',
-          'builder': function(val, bufb, codec) { self._mapBuilder(val, bufb, codec, 4); },
-          'decoder': function(buf, codec) { return self._mapDecoder(4, buf, codec); }
+          code: 0xd1,
+          category: 'compound',
+          width: 4,
+          label: 'up to 2^32 - 1 octets of encoded map data',
+          builder: function(val, bufb, codec) { self._mapBuilder(val, bufb, codec, 4); },
+          decoder: function(buf, codec) { return self._mapDecoder(4, buf, codec); }
         }
       ]
     },
     {
-      'class': 'primitive',
-      'name': 'array',
-      'label': 'a sequence of values of a single type',
-      'builder': function(val, bufb, codec) { self._arrayBuilder(val, bufb, codec); },
-      'encodings': [
+      class: 'primitive',
+      name: 'array',
+      label: 'a sequence of values of a single type',
+      builder: function(val, bufb, codec) { self._arrayBuilder(val, bufb, codec); },
+      encodings: [
         {
-          'code': '0xe0',
-          'category': 'array',
-          'width': '1',
-          'label': 'up to 2^8 - 1 array elements with total size less than 2^8 octets',
-          'builder': function(val, bufb, codec) { self._arrayBuilder(val, bufb, codec, 1); },
-          'decoder': function(buf, codec) { return self._arrayDecoder(1, buf, codec); }
+          code: 0xe0,
+          category: 'array',
+          width: 1,
+          label: 'up to 2^8 - 1 array elements with total size less than 2^8 octets',
+          builder: function(val, bufb, codec) { self._arrayBuilder(val, bufb, codec, 1); },
+          decoder: function(buf, codec) { return self._arrayDecoder(1, buf, codec); }
         },
         {
-          'code': '0xf0',
-          'category': 'array',
-          'width': '4',
-          'label': 'up to 2^32 - 1 array elements with total size less than 2^32 octets',
-          'builder': function(val, bufb, codec) { self._arrayBuilder(val, bufb, codec, 4); },
-          'decoder': function(buf, codec) { return self._arrayDecoder(4, buf, codec); }
+          code: 0xf0,
+          category: 'array',
+          width: 4,
+          label: 'up to 2^32 - 1 array elements with total size less than 2^32 octets',
+          builder: function(val, bufb, codec) { self._arrayBuilder(val, bufb, codec, 4); },
+          decoder: function(buf, codec) { return self._arrayDecoder(4, buf, codec); }
         }
       ]
     }
@@ -1026,17 +1034,17 @@ Types.prototype._initEncodersDecoders = function() {
   this.builders = {};
   this.buildersByCode = {};
   this.decoders = {};
-  for (var idx in this.typesArray) {
-    var curType = this.typesArray[idx];
-    this.typesByName[curType.name] = curType;
-    this.builders[curType.name] = curType.builder;
-    for (var encIdx in curType.encodings) {
-      var curEnc = curType.encodings[encIdx];
-      var curCode = parseInt(curEnc.code);
-      this.decoders[curCode] = curEnc.decoder;
-      this.buildersByCode[curCode] = curEnc.builder;
-    }
-  }
+
+  var self = this;
+  this.typesArray.forEach(function(type) {
+    self.typesByName[type.name] = type;
+    self.builders[type.name] = type.builder;
+
+    type.encodings.forEach(function(encoding) {
+      self.decoders[encoding.code] = encoding.decoder;
+      self.buildersByCode[encoding.code] = encoding.builder;
+    });
+  });
 };
 
 module.exports = new Types();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "buffer-builder": "^0.2.0",
-    "butils": "^0.1.0",
     "bl": "^0.9.4",
     "debug": "^2.0.0",
     "lodash": "^3.3.0",

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -33,8 +33,8 @@ describe('Types', function() {
       describe('scalar', function() {
         [
           { name: 'null', value: null, expectedOutput: buf([0x40]) },
-          { name: 'boolean(true)', type: 'boolean', value: true, expectedOutput: buf([0x41]) },
-          { name: 'boolean(false)', type: 'boolean', value: false, expectedOutput: buf([0x42]) },
+          { name: 'true', type: 'boolean', value: true, expectedOutput: buf([0x41]) },
+          { name: 'false', type: 'boolean', value: false, expectedOutput: buf([0x42]) },
           {
             name: 'uint', value: 10000,
             expectedOutput: buf([0x70, builder.prototype.appendUInt32BE, 10000])
@@ -104,10 +104,6 @@ describe('Types', function() {
         expect(decode).to.be.an.instanceOf(Function);
 
         var actual = decode(test.value, codec);
-        if (actual instanceof Buffer) {
-          console.log(actual.toString());
-        }
-
         expect(actual).to.eql(test.expectedOutput);
       });
     }

--- a/tools/formatRx.js
+++ b/tools/formatRx.js
@@ -3,7 +3,6 @@
 var fs = require('fs'),
   util = require('util'),
   int64 = require('node-int64'),
-  butils = require('butils'),
   constants = require('../lib/constants');
 
 if (process.argv.length < 3) {


### PR DESCRIPTION
butils is not needed, so this removes it for the sake of "buffer
purity". Also, I've cleaned up the types array removing needless
string allocations.