### PR TITLE
test(encoding-decoding): improve test coverage for encoding/decoding

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -78,13 +78,17 @@ Codec.prototype._readFullValue = function(buf, offset, doNotConsume, forcedCode)
         return [[val1[0], val2[0]], totalBytes];
       }
     }
+
     return undefined;
   }
 
   var codePrefix = code & 0xF0;
   var codeAndLength, numBytes;
   var reader = doNotConsume ? self._peek : self._read;
-  var readFixed = function(nBytes) { return remaining >= nBytes ? [reader(buf, offset, nBytes), nBytes] : undefined; };
+  var readFixed = function(nBytes) {
+    return remaining >= nBytes ? [reader(buf, offset, nBytes), nBytes] : undefined;
+  };
+
   switch (codePrefix) {
     case 0x40: return readFixed(1);
     case 0x50: return readFixed(2);
@@ -96,6 +100,7 @@ Codec.prototype._readFullValue = function(buf, offset, doNotConsume, forcedCode)
     case 0xC0:
     case 0xE0:
       if (remaining < 2) return undefined;
+
       codeAndLength = this._peek(buf, offset, codeBytes + 1);
       numBytes = codeAndLength[codeBytes] + 1 + codeBytes; // code + size + # octets
       //debug('Reading variable with prefix 0x'+codePrefix.toString(16)+' of length '+numBytes);
@@ -104,6 +109,7 @@ Codec.prototype._readFullValue = function(buf, offset, doNotConsume, forcedCode)
     case 0xD0:
     case 0xF0:
       if (remaining < 5) return false;
+
       codeAndLength = this._peek(buf, offset, codeBytes + 4);
       numBytes = codeAndLength.readUInt32BE(codeBytes) + 4 + codeBytes; // code + size + #octets
       //debug('Reading variable with prefix 0x'+codePrefix.toString(16)+' of length '+numBytes);
@@ -115,7 +121,7 @@ Codec.prototype._readFullValue = function(buf, offset, doNotConsume, forcedCode)
 };
 
 Codec.prototype._decode = function(buf, forcedCode) {
-  //debug('Decoding '+buf.toString('hex'));
+  // debug('Decoding '+buf.toString('hex'));
   var code = forcedCode || buf[0];
   var decoder = types.decoders[code];
   if (!decoder) {
@@ -149,6 +155,9 @@ Codec.prototype._asMostSpecific = function(buf, forcedCode) {
  * @return {Array}                      Single decoded value + number of bytes consumed.
  */
 Codec.prototype.decode = function(buf, offset, forcedCode) {
+  offset = offset || 0;
+  forcedCode = forcedCode || undefined;
+
   var fullBuf = this._readFullValue(buf, offset, /* doNotConsume= */false, forcedCode);
   if (fullBuf) {
     var bufVal = fullBuf[0];
@@ -178,6 +187,7 @@ Codec.prototype.decode = function(buf, offset, forcedCode) {
 Codec.prototype.encode = function(val, buf, forceType) {
   var type = typeof val;
   var encoder;
+
   // Special-case null values
   if (val === null) {
     encoder = types.builders.null;
@@ -231,12 +241,16 @@ Codec.prototype.encode = function(val, buf, forceType) {
         this.encode(val.getValue() || [], buf);
         return;
       } else if (val instanceof Int64) {
-        encoder = types.builders.ulong;
-        if (val < 0) encoder = types.builders.long;
-        encoder(val, buf, this);
+        if (!!forceType) {
+          encoder = types.builders[forceType];
+        } else {
+          encoder = (val < 0) ? types.builders.long: types.builders.ulong;
+        }
+
+        return encoder(val, buf, this);
       } else if (val instanceof AMQPSymbol) {
         encoder = types.builders.symbol;
-        encoder(val.contents, buf, this);
+        return encoder(val.contents, buf, this);
       } else if (val.encodeOrdering && val.encodeOrdering instanceof Array) {
         // Encoding an object's values in a specific ordering as a list.
         var asList = []; // LINQify

--- a/lib/types.js
+++ b/lib/types.js
@@ -465,8 +465,17 @@ Types.prototype._initTypesArray = function() {
       label: 'integer in the range 0 to 2^64 - 1 inclusive',
       builder: function(val, bufb) {
         if (val instanceof Int64 || val > 0xFF) {
-          bufb.appendUInt8(0x80);
-          self.buildersByCode[0x80](val, bufb);
+          var check = (val instanceof Int64) ? val.toNumber(true) : val;
+
+          var code = 0x80;
+          if (check === 0) {
+            code = 0x44;
+          } else if (check <= 0xFF) {
+            code = 0x53;
+          }
+
+          bufb.appendUInt8(code);
+          self.buildersByCode[code](val, bufb);
         } else if (val === 0) {
           bufb.appendUInt8(0x44);
         } else if (val > 0 && val <= 0xFF) {
@@ -511,7 +520,7 @@ Types.prototype._initTypesArray = function() {
           category: 'fixed',
           width: 0,
           label: 'the ulong value 0',
-          builder: function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
+          builder: function(val, bufb) {},
           decoder: function(buf) { return new Int64(0, 0); }
         }
       ]
@@ -559,8 +568,13 @@ Types.prototype._initTypesArray = function() {
       name: 'int',
       label: 'integer in the range -(2^31) to 2^31 - 1 inclusive',
       builder: function(val, bufb) {
-        bufb.appendUInt8(0x71);
-        bufb.appendInt32BE(val);
+        if (Math.abs(val) < 0x80) {
+          bufb.appendUInt8(0x54);
+          bufb.appendUInt8(val);
+        } else {
+          bufb.appendUInt8(0x71);
+          bufb.appendInt32BE(val);
+        }
       },
       encodings: [
         {
@@ -586,8 +600,14 @@ Types.prototype._initTypesArray = function() {
       name: 'long',
       label: 'integer in the range -(2^63) to 2^63 - 1 inclusive',
       builder: function(val, bufb) {
-        bufb.appendUInt8(0x81);
-        self.buildersByCode[0x81](val, bufb); // @todo Deal with Math.abs(val) < 0x7F cases
+        var code = 0x81;
+        var check = (val instanceof Int64) ? val.toNumber(true) : val;
+        if (Math.abs(check) < 0x80) {
+          code = 0x55;
+        }
+
+        bufb.appendUInt8(code);
+        self.buildersByCode[code](val, bufb); // @todo Deal with Math.abs(val) < 0x7F cases
       },
       encodings: [
         {

--- a/test/test_codec.js
+++ b/test/test_codec.js
@@ -215,7 +215,7 @@ describe('Codec', function() {
     });
     it('should encode lists', function() {
       var list = [1, 'foo'];
-      var expected = buildBuffer([0xC0, (1 + 5 + 5), 2, 0x71, 0, 0, 0, 1, 0xA1, 3, builder.prototype.appendString, 'foo']);
+      var expected = buildBuffer([0xC0, (1 + 2 + 5), 2, 0x54, 1, 0xA1, 3, builder.prototype.appendString, 'foo']);
       var bufb = new builder();
       codec.encode(list, bufb);
       tu.shouldBufEql(expected, bufb);
@@ -235,7 +235,7 @@ describe('Codec', function() {
     it('should encode described types with no values', function() {
       var bufb = new builder();
       codec.encode(new DescribedType(new Int64(0x0, 0x26)), bufb);
-      var expected = buildBuffer([0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x26, 0x45]);
+      var expected = buildBuffer([0x00, 0x53, 0x26, 0x45]);
       tu.shouldBufEql(expected, bufb);
     });
     it('should encode objects as lists when asked', function() {
@@ -317,9 +317,9 @@ describe('Codec', function() {
           'incomingLocales', 'offeredCapabilities', 'desiredCapabilities', 'properties']
       });
       var expected = buildBuffer([0x00,
-        0x80, builder.prototype.appendUInt32BE, 0x0, builder.prototype.appendUInt32BE, 0x10, // Descriptor
+        0x53, 0x10, // Descriptor
         // 0xD0, builder.prototype.appendUInt32BE, 0x0, builder.prototype.appendUInt32BE, 0x0, // List (size & count)
-        0xC0, (1 + 8 + 11 + 5 + 3 + 5 + 7 + 7 + 1 + 1 + 3), 10,
+        0xC0, 0x34, 10,
         0xA1, 0x6, builder.prototype.appendString, 'client', // ID
         0xA1, 0x9, builder.prototype.appendString, 'localhost', // Hostname
         0x70, builder.prototype.appendUInt32BE, 512, // Max Frame Size

--- a/test/test_frame_encodings.js
+++ b/test/test_frame_encodings.js
@@ -32,11 +32,11 @@ describe('OpenFrame', function() {
     var open = new OpenFrame({ containerId: 'test', hostname: 'localhost' });
     var actual = tu.convertFrameToBuffer(open);
     var expected = tu.buildBuffer([
-      0x00, 0x00, 0x00, 0x46,
+      0x00, 0x00, 0x00, 0x3f,
       0x02, 0x00, 0x00, 0x00,
       0x00,
-      0x80, 0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x10,
+      0x53,
+      0x10,
       0xc0, 0x32, 0x0a, // list
       0xa1, 4, builder.prototype.appendString, 'test',
       0xa1, 9, builder.prototype.appendString, 'localhost',
@@ -58,11 +58,11 @@ describe('BeginFrame', function() {
     begin.channel = 1;
     var actual = tu.convertFrameToBuffer(begin);
     var expected = tu.buildBuffer([
-      0x00, 0x00, 0x00, 0x26,
+      0x00, 0x00, 0x00, 0x1F,
       0x02, 0x00, 0x00, 0x01,
       0x00,
-      0x80, 0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x11,
+      0x53,
+      0x11,
       0xc0, 0x12, 0x08, // list
       0x40,
       0x52, 0x01,
@@ -89,22 +89,22 @@ describe('AttachFrame', function() {
     var actual = tu.convertFrameToBuffer(attach);
     var sourceSize = 1 + 1 + 1 + 13 + 1 + 1 + 3 + 1 + 3 + 1 + 1 + 1;
     var targetSize = 1 + 9 + 1 + 13 + 1 + 1 + 3 + 1;
-    var listSize = 1 + 6 + 2 + 1 + 2 + 2 + 10 + 2 + sourceSize + 10 + 2 + targetSize + 3 + 1 + 2 + 1 + 1 + 1 + 3;
+    var listSize = 1 + 6 + 2 + 1 + 2 + 2 + 3 + 2 + sourceSize + 3 + 2 + targetSize + 3 + 1 + 2 + 1 + 1 + 1 + 3;
     var listCount = 14;
-    var frameSize = 8 + 1 + 9 + 2 + listSize;
+    var frameSize = 1 + 1 + 9 + 2 + listSize;
     var expected = tu.buildBuffer([
       0x00, 0x00, 0x00, frameSize,
       0x02, 0x00, 0x00, 0x01,
       0x00,
-      0x80, 0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x12,
+      0x53,
+      0x12,
       0xc0, listSize, listCount,
       0xA1, 4, builder.prototype.appendString, 'test',
       0x52, 1, // handle
       0x42, // role=sender
       0x50, 2, // sender-settle-mode=mixed
       0x50, 0, // rcv-settle-mode=first
-      0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x28, // source
+      0x00, 0x53, 0x28, // source
       0xc0, sourceSize, 11,
       0x40,
       0x43,
@@ -117,7 +117,7 @@ describe('AttachFrame', function() {
       0x40,
       0x40,
       0x40,
-      0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x29, // target
+      0x00, 0x53, 0x29, // target
       0xc0, targetSize, 7,
       0xA1, 7, builder.prototype.appendString, 'testtgt',
       0x43,
@@ -156,13 +156,13 @@ describe('FlowFrame', function() {
     flow.channel = 1;
     var actual = tu.convertFrameToBuffer(flow);
     var listSize = 1 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 1 + 1 + 1 + 3;
-    var frameSize = 8 + 1 + 9 + 2 + listSize;
+    var frameSize = 1 + 1 + 9 + 2 + listSize;
     var expected = tu.buildBuffer([
       0x00, 0x00, 0x00, frameSize,
       0x02, 0x00, 0x00, 0x01,
       0x00,
-      0x80, 0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x13,
+      0x53,
+      0x13,
       0xc0, listSize, 11,
       0x52, 1,
       0x52, 100,
@@ -197,13 +197,13 @@ describe('TransferFrame', function() {
     var actual = tu.convertFrameToBuffer(transfer);
     var payloadSize = 12;
     var listSize = 1 + 2 + 2 + 3 + 5 + 1 + 1 + 2 + 1 + 1 + 1 + 1;
-    var frameSize = 8 + 1 + 9 + 2 + listSize + payloadSize;
+    var frameSize = 1 + 1 + 2 + 2 + listSize + payloadSize;
     var expected = tu.buildBuffer([
       0x00, 0x00, 0x00, frameSize,
       0x02, 0x00, 0x00, 0x01,
       0x00,
-      0x80, 0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x14,
+      0x53,
+      0x14,
       0xc0, listSize, 11,
       0x52, 1, // handle
       0x52, 1, // delivery-id
@@ -215,7 +215,7 @@ describe('TransferFrame', function() {
       0x40, // state
       0x42, 0x42, 0x42, // resume/aborted/batchable
       // Message Body - amqp-value of uint(10)
-      0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x77,
+      0x00, 0x53, 0x77,
       0x52, 10
     ]);
 
@@ -228,13 +228,12 @@ describe('SaslFrames', function() {
     it('should encode correctly', function() {
       var mechanisms = new Sasl.SaslMechanisms();
       var actual = tu.convertFrameToBuffer(mechanisms);
-      var frameSize = 8 + 1 + 9 + 3 + 2 + 'ANONYMOUS'.length;
+      var frameSize = 8 + 1 + 2 + 3 + 2 + 'ANONYMOUS'.length;
       var expected = tu.buildBuffer([
         0x00, 0x00, 0x00, frameSize,
         0x02, 0x01, 0x00, 0x00,
         0x00,
-        0x80, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x40,
+        0x53, 0x40,
         0xC0, 9 + 3, 1,
         0xA3, 9, builder.prototype.appendString, 'ANONYMOUS'
       ]);

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -221,7 +221,20 @@ describe('Types', function() {
           { name: 'list0', type: 0x45, value: new Buffer([]), expectedOutput: [] },
           {
             name: 'list8', type: 0xC0,
-            value: buf([0xB, 0x2, 0x71, builder.prototype.appendInt32BE, 123, 0x71, builder.prototype.appendInt32BE, 456]),
+            value: buf([
+              0xC, 0x2,
+              0x71, builder.prototype.appendInt32BE, 123,
+              0x71, builder.prototype.appendInt32BE, 456
+            ]),
+            expectedOutput: [123, 456]
+          },
+          {
+            name: 'list32', type: 0xD0,
+            value: buf([
+              builder.prototype.appendUInt32BE, 0xD,  builder.prototype.appendUInt32BE, 0x2,
+              0x71, builder.prototype.appendInt32BE, 123,
+              0x71, builder.prototype.appendInt32BE, 456
+            ]),
             expectedOutput: [123, 456]
           },
           {

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -10,6 +10,7 @@ var assert = require('assert'),
 
     types = require('../lib/types'),
     codec = require('../lib/codec'),
+    ForcedType = require('../lib/types/forced_type'),
 
     AMQPSymbol = require('../lib/types/amqp_symbol'),
 
@@ -21,145 +22,102 @@ describe('Types', function() {
   describe('#encoding', function() {
     function testEncoding(test) {
       it(test.name, function() {
-        var encode = types.builders[test.type || test.name];
-        expect(encode).to.not.be.undefined;
+        var type = test.type || test.name;
         var buffer = new BufferBuilder();
-        encode(test.value, buffer, codec);
+        codec.encode(new ForcedType(type, test.value), buffer);
         tu.shouldBufEql(test.expectedOutput, buffer.get());
       });
     }
 
     describe('primitives', function() {
       describe('scalar', function() {
+        var str32Utf8String;
+        var sym32String;
+        for (var i = 0; i < 500; ++i) {
+          str32Utf8String += 'f';
+          sym32String += 'a';
+        }
+
+        var str32Utf8StringExpectedBuffer = [
+          0xb1,
+          builder.prototype.appendUInt32BE, str32Utf8String.length,
+          builder.prototype.appendString, str32Utf8String
+        ];
+
+        var sym32StringExpectedBuffer = [
+          0xb3,
+          builder.prototype.appendUInt32BE, sym32String.length,
+          builder.prototype.appendString, sym32String
+        ];
+
         [
           { name: 'null', value: null, expectedOutput: buf([0x40]) },
           { name: 'true', type: 'boolean', value: true, expectedOutput: buf([0x41]) },
           { name: 'false', type: 'boolean', value: false, expectedOutput: buf([0x42]) },
+          { name: 'ubyte', value: 1, expectedOutput: buf([0x50, 0x01]) },
+          { name: 'ushort', value: 1, expectedOutput: buf([0x60, 0x00, 0x01]) },
+
           {
-            name: 'uint', value: 10000,
-            expectedOutput: buf([0x70, builder.prototype.appendUInt32BE, 10000])
+            name: 'uint', value: 20000,
+            expectedOutput: buf([0x70, builder.prototype.appendInt32BE, 20000])
+          },
+          { name: 'smalluint', type: 'uint', value: 1, expectedOutput: buf([0x52, 0x01]) },
+          { name: 'uint0', type: 'uint', value: 0, expectedOutput: buf([0x43]) },
+
+          {
+            name: 'ulong',
+            value: 256,
+            expectedOutput: buf([0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00])
           },
           {
-            name: 'uint', value: 100,
-            expectedOutput: buf([0x52, builder.prototype.appendUInt8, 100])
+            name: 'ulong (int64)', type: 'ulong',
+            value: new Int64(0x11111111, 0x11111111),
+            expectedOutput: buf([0x80, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11])
           },
-          { name: 'uint', value: 0, expectedOutput: buf([0x43]) },
           {
-            name: 'int', value: -10000,
-            expectedOutput: buf([0x71, builder.prototype.appendInt32BE, -10000])
+            name: 'smallulong', type: 'ulong',
+            value: 127,
+            expectedOutput: buf([0x53, 0x7f])
+          },
+          {
+            name: 'smallulong (int64)', type: 'ulong',
+            value: new Int64(0x00000000, 0x00000001),
+            expectedOutput: buf([0x53, 0x01])
+          },
+          {
+            name: 'ulong0', type: 'ulong',
+            value: new Int64(0x00000000, 0x00000000),
+            expectedOutput: buf([0x44])
+          },
+          { name: 'byte', value: 1, expectedOutput: buf([0x51, 0x01]) },
+          { name: 'short', value: 1, expectedOutput: buf([0x61, 0x00, 0x01]) },
+          { name: 'int', value: 129, expectedOutput: buf([0x71, 0x00, 0x00, 0x00, 0x81]) },
+          { name: 'smallint', type: 'int', value: 1, expectedOutput: buf([0x54, 0x01]) },
+          {
+            name: 'long', value: 129,
+            expectedOutput: buf([0x81, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x81])
+          },
+          {
+            name: 'long (int64)', type: 'long',
+            value: new Int64(0x11111111, 0x11111111),
+            expectedOutput: buf([0x81, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11])
+          },
+          { name: 'smalllong', type: 'long', value: 127, expectedOutput: buf([0x55, 0x7f]) },
+          {
+            name: 'smalllong (int64)', type: 'long',
+            value: new Int64(127),
+            expectedOutput: buf([0x55, 0x7f])
+          },
+          {
+            name: 'float',
+            value: 3.14,
+            expectedOutput: buf([0x72, builder.prototype.appendFloatBE, 3.14])
           },
           {
             name: 'double', value: 123.45,
             expectedOutput: buf([0x82, builder.prototype.appendDoubleBE, 123.45])
           },
-          {
-            name: 'long', value: new Int64(0xFFFFFFFF, 0xFFFFFFFF),
-            expectedOutput: buf([0x81, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
-          },
-          {
-            name: 'string', value: 'foo',
-            expectedOutput: buf([0xA1, 0x03, builder.prototype.appendString, 'foo'])
-          }
-        ].forEach(testEncoding);
-      });
 
-      describe('collection', function() {
-        [
-          { name: 'list(empty)', type: 'list', value: [], expectedOutput: buf([0x45]) },
-          {
-            name: 'list', value: [123, 456],
-            expectedOutput: buf([0xC0, 0xB, 0x2, 0x71, builder.prototype.appendInt32BE, 123, 0x71, builder.prototype.appendInt32BE, 456])
-          },
-          { name: 'map(empty)', type: 'map', value: {}, expectedOutput: buf([0xc1, 0x1, 0x0]) },
-          {
-            name: 'map', value: { foo: 123, bar: 45.6 },
-            expectedOutput: buf([0xD1,
-              builder.prototype.appendUInt32BE, 0x1c, builder.prototype.appendUInt32BE, 0x04,
-              0xA1, 0x03, builder.prototype.appendString, 'foo',
-              0x71, builder.prototype.appendInt32BE, 123,
-              0xA1, 0x03, builder.prototype.appendString, 'bar',
-              0x82, builder.prototype.appendDoubleBE, 45.6])
-          },
-          {
-            name: 'map(nested)', type: 'map', value: { baz: { zap: 'bop' } },
-            expectedOutput: buf([0xD1,
-             builder.prototype.appendUInt32BE, 0x1c, builder.prototype.appendUInt32BE, 0x02,
-             0xA1, 0x03, builder.prototype.appendString, 'baz',
-             0xD1, builder.prototype.appendUInt32BE, 0x0e, builder.prototype.appendUInt32BE, 0x02,
-             0xA1, 0x03, builder.prototype.appendString, 'zap',
-             0xA1, 0x03, builder.prototype.appendString, 'bop'
-            ])
-          }
-        ].forEach(testEncoding);
-      });
-    });
-  });
-
-  describe('#decoding', function() {
-
-    function testDecoding(test) {
-      it(test.name, function() {
-        var decode = types.decoders[test.type];
-        expect(decode).to.not.be.undefined;
-        expect(decode).to.be.an.instanceOf(Function);
-
-        var actual = decode(test.value, codec);
-        expect(actual).to.eql(test.expectedOutput);
-      });
-    }
-
-    describe('primitives', function() {
-      describe('scalar', function() {
-        [
-          { name: 'null', type: 0x40, value: new Buffer([]), expectedOutput: null },
-          { name: 'true', type: 0x41, value: new Buffer([]), expectedOutput: true },
-          { name: 'false', type: 0x42, value: new Buffer([]), expectedOutput: false },
-          { name: 'boolean(true)', type: 0x56, value: buf([0x01]), expectedOutput: true },
-          { name: 'boolean(false)', type: 0x56, value: buf([0x00]), expectedOutput: false },
-          { name: 'ubyte', type: 0x50, value: buf([0x01]), expectedOutput: 1 },
-          { name: 'ushort', type: 0x60, value: buf([0x00, 0x01]), expectedOutput: 1 },
-          {
-            name: 'uint', type: 0x70,
-            value: buf([builder.prototype.appendInt32BE, 123]),
-            expectedOutput: 123
-          },
-          { name: 'smalluint', type: 0x52, value: buf([0x01]), expectedOutput: 1 },
-          { name: 'uint0', type: 0x43, value: new Buffer([]), expectedOutput: 0 },
-
-          {
-            name: 'ulong', type: 0x80,
-            value: buf([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
-            expectedOutput: new Int64(0xFFFFFFFF, 0xFFFFFFFF)
-          },
-          {
-            name: 'smallulong', type: 0x53, value: buf([0x01]),
-            expectedOutput: new Int64(0x00000000, 0x00000001)
-          },
-          {
-            name: 'ulong0', type: 0x44,
-            value: buf([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-            expectedOutput: new Int64(0x00000000, 0x00000000)
-          },
-          { name: 'byte', type: 0x51, value: buf([0x01]), expectedOutput: 1 },
-          { name: 'short', type: 0x61, value: buf([0x00, 0x01]), expectedOutput: 1 },
-          { name: 'int', type: 0x71, value: buf([0x00, 0x00, 0x00, 0x01]), expectedOutput: 1 },
-          { name: 'smallint', type: 0x54, value: buf([0x01]), expectedOutput: 1 },
-          {
-            name: 'long', type: 0x81,
-            value: buf([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
-            expectedOutput: new Int64(0xFFFFFFFF, 0xFFFFFFFF)
-          },
-          { name: 'smalllong', type: 0x55, value: buf([0x23]), expectedOutput: 0x23 },
-          // {
-          //   name: 'float', type: 0x72,
-          //   value: buf([builder.prototype.appendFloatBE, 123.45]),
-          //   expectedOutput: 123.45
-          // },
-          {
-            name: 'double', type: 0x82,
-            value: buf([builder.prototype.appendDoubleBE, 123.45]),
-            expectedOutput: 123.45
-          },
           // { name: 'decimal32', type: 0x74, value: buf([0x00, 0x01, 0x00, 0x01]), expectedOutput: 1.1 },
           // {
           //   name: 'decimal64', type: 0x84,
@@ -192,25 +150,200 @@ describe('Types', function() {
           // { name: 'vin32', type: 0xb0, value: buf([0x01, 0x02, 0x03, 0x04]), expectedOutput: new Buffer([0x01, 0x02, 0x03, 0x04]) },
 
           {
-            name: 'str8-utf8', type: 0xa1,
-            value: buf([3, builder.prototype.appendString, 'foo']),
-            expectedOutput: 'foo'
-          },
-          { name: 'str8-utf8 (empty)', type: 0xa1, value: buf([0]), expectedOutput: '' },
-          {
-            name: 'str32-utf8', type: 0xb1,
-            value: buf([builder.prototype.appendUInt32BE, 3, builder.prototype.appendString, 'foo']),
-            expectedOutput: 'foo'
+            name: 'str8-utf8', type: 'string',
+            value: 'foo',
+            expectedOutput: buf([0xa1, 3, builder.prototype.appendString, 'foo'])
           },
           {
-            name: 'sym8', type: 0xa3,
-            value: buf([3, builder.prototype.appendString, 'foo']),
+            name: 'str8-utf8 (empty)', type: 'string',
+            value: '',
+            expectedOutput: buf([0xa1, 0])
+          },
+          {
+            name: 'str32-utf8', type: 'string', value: str32Utf8String,
+            expectedOutput: buf(str32Utf8StringExpectedBuffer)
+          },
+          {
+            name: 'sym8', type: 'symbol', value: new AMQPSymbol('foo'),
+            expectedOutput: buf([0xa3, 3, builder.prototype.appendString, 'foo'])
+          },
+          {
+            name: 'sym8 (empty)', type: 'symbol',
+            value: new AMQPSymbol(''),
+            expectedOutput: buf([0xa3, 0]) },
+          {
+            name: 'sym32', type: 'symbol',
+            value: new AMQPSymbol(sym32String),
+            expectedOutput: buf(sym32StringExpectedBuffer)
+          }
+        ].forEach(testEncoding);
+      });
+
+      describe('collection', function() {
+        [
+          { name: 'list(empty)', type: 'list', value: [], expectedOutput: buf([0x45]) },
+          {
+            name: 'list', value: [456, 789],
+            expectedOutput: buf([
+              0xC0,
+              0xB, 0x2,
+              0x71, builder.prototype.appendInt32BE, 456,
+              0x71, builder.prototype.appendInt32BE, 789
+            ])
+          },
+          { name: 'map(empty)', type: 'map', value: {}, expectedOutput: buf([0xc1, 0x1, 0x0]) },
+          {
+            name: 'map', value: { foo: 456, bar: 45.6 },
+            expectedOutput: buf([
+              0xD1,
+              builder.prototype.appendUInt32BE, 0x1c, builder.prototype.appendUInt32BE, 0x04,
+              0xA1, 0x03, builder.prototype.appendString, 'foo',
+              0x71, builder.prototype.appendInt32BE, 456,
+              0xA1, 0x03, builder.prototype.appendString, 'bar',
+              0x82, builder.prototype.appendDoubleBE, 45.6
+            ])
+          },
+          {
+            name: 'map(nested)', type: 'map', value: { baz: { zap: 'bop' } },
+            expectedOutput: buf([
+              0xD1,
+              builder.prototype.appendUInt32BE, 0x1c, builder.prototype.appendUInt32BE, 0x02,
+              0xA1, 0x03, builder.prototype.appendString, 'baz',
+              0xD1, builder.prototype.appendUInt32BE, 0x0e, builder.prototype.appendUInt32BE, 0x02,
+              0xA1, 0x03, builder.prototype.appendString, 'zap',
+              0xA1, 0x03, builder.prototype.appendString, 'bop'
+            ])
+          }
+        ].forEach(testEncoding);
+      });
+    });
+  });
+
+  describe('#decoding', function() {
+    function testDecoding(test) {
+      it(test.name, function() {
+        var actualOutput = codec.decode(test.value)[0];
+        if (test.name === 'float') {
+          // NOTE: this is pretty cheesy, but so is dealing with
+          //       floating point precision...
+          actualOutput = parseFloat(actualOutput.toFixed(2));
+        }
+
+        expect(actualOutput).to.eql(test.expectedOutput);
+      });
+    }
+
+    describe('primitives', function() {
+      describe('scalar', function() {
+        [
+          { name: 'null', value: buf([0x40]), expectedOutput: null },
+          { name: 'true', value: buf([0x41]), expectedOutput: true },
+          { name: 'false', value: buf([0x42]), expectedOutput: false },
+          { name: 'boolean(true)', value: buf([0x56, 0x01]), expectedOutput: true },
+          { name: 'boolean(false)', value: buf([0x56, 0x00]), expectedOutput: false },
+          { name: 'ubyte', value: buf([0x50, 0x01]), expectedOutput: 1 },
+          { name: 'ushort', value: buf([0x60, 0x00, 0x01]), expectedOutput: 1 },
+          {
+            name: 'uint',
+            value: buf([0x70, builder.prototype.appendInt32BE, 123]),
+            expectedOutput: 123
+          },
+          { name: 'smalluint', value: buf([0x52, 0x01]), expectedOutput: 1 },
+          { name: 'uint0', value: buf([0x43]), expectedOutput: 0 },
+
+          {
+            name: 'ulong',
+            value: buf([0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+            expectedOutput: new Int64(0xFFFFFFFF, 0xFFFFFFFF)
+          },
+          {
+            name: 'smallulong', value: buf([0x53, 0x01]),
+            expectedOutput: new Int64(0x00000000, 0x00000001)
+          },
+          {
+            name: 'ulong0',
+            value: buf([0x44]),
+            expectedOutput: new Int64(0x00000000, 0x00000000)
+          },
+          { name: 'byte', value: buf([0x51, 0x01]), expectedOutput: 1 },
+          { name: 'short', value: buf([0x61, 0x00, 0x01]), expectedOutput: 1 },
+          { name: 'int', value: buf([0x71, 0x00, 0x00, 0x00, 0x01]), expectedOutput: 1 },
+          { name: 'smallint', value: buf([0x54, 0x01]), expectedOutput: 1 },
+          {
+            name: 'long',
+            value: buf([0x81, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+            expectedOutput: new Int64(0xFFFFFFFF, 0xFFFFFFFF)
+          },
+          { name: 'smalllong', value: buf([0x55, 0x23]), expectedOutput: 0x23 },
+          {
+            name: 'float',
+            value: buf([0x72, builder.prototype.appendFloatBE, 3.14]),
+            expectedOutput: 3.14
+          },
+          {
+            name: 'double',
+            value: buf([0x82, builder.prototype.appendDoubleBE, 123.45]),
+            expectedOutput: 123.45
+          },
+          // { name: 'decimal32', type: 0x74, value: buf([0x00, 0x01, 0x00, 0x01]), expectedOutput: 1.1 },
+          // {
+          //   name: 'decimal64', type: 0x84,
+          //   value: buf([0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01]),
+          //   expectedOutput: 1.1
+          // },
+          // {
+          //   name: 'decimal128', type: 0x94,
+          //   value: buf([
+          //     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+          //     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+          //   ]),
+          //   expectedOutput: 1.1
+          // },
+          // { name: 'utf32 (char)', type: 0x73, value: buf([0x24]), expectedOutput: '$' },
+          // {
+          //   name: 'uuid', type: 0x98,
+          //   value: buf([
+          //     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+          //     0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16
+          //   ]),
+          //   expectedOutput: 'some uuid'
+          // },
+
+          {
+            name: 'ms64 (timestamp)',
+            value: buf([0x83, 0x00, 0x00, 0x00, 0x00, 0x55, 0x10, 0x7B, 0x38]),
+            expectedOutput: new Int64(1427143480)
+          },
+          { name: 'vbin8', value: buf([0xa0, 0x01, 0x10]), expectedOutput: new Buffer([0x10]) },
+          {
+            name: 'vbin32',
+            value: buf([
+              0xb0,
+              builder.prototype.appendUInt32BE, 0x04,
+              0x01, 0x02, 0x03, 0x04
+            ]),
+            expectedOutput: new Buffer([0x01, 0x02, 0x03, 0x04]) },
+
+          {
+            name: 'str8-utf8',
+            value: buf([0xa1, 3, builder.prototype.appendString, 'foo']),
+            expectedOutput: 'foo'
+          },
+          { name: 'str8-utf8 (empty)', value: buf([0xa1, 0]), expectedOutput: '' },
+          {
+            name: 'str32-utf8',
+            value: buf([0xb1, builder.prototype.appendUInt32BE, 3, builder.prototype.appendString, 'foo']),
+            expectedOutput: 'foo'
+          },
+          {
+            name: 'sym8',
+            value: buf([0xa3, 3, builder.prototype.appendString, 'foo']),
             expectedOutput: new AMQPSymbol('foo')
           },
-          { name: 'sym8 (empty)', type: 0xa3, value: buf([0]), expectedOutput: new AMQPSymbol('') },
+          { name: 'sym8 (empty)', value: buf([0xa3, 0]), expectedOutput: new AMQPSymbol('') },
           {
-            name: 'sym32', type: 0xb3,
-            value: buf([builder.prototype.appendUInt32BE, 3, builder.prototype.appendString, 'foo']),
+            name: 'sym32',
+            value: buf([0xb3, builder.prototype.appendUInt32BE, 3, builder.prototype.appendString, 'foo']),
             expectedOutput: new AMQPSymbol('foo')
           },
         ].forEach(testDecoding);
@@ -218,36 +351,42 @@ describe('Types', function() {
 
       describe('collection', function() {
         [
-          { name: 'list0', type: 0x45, value: new Buffer([]), expectedOutput: [] },
+          { name: 'list0', value: buf([0x45]), expectedOutput: [] },
           {
-            name: 'list8', type: 0xC0,
+            name: 'list8',
             value: buf([
-              0xC, 0x2,
+              0xC0,
+              0xB, 0x2,
               0x71, builder.prototype.appendInt32BE, 123,
               0x71, builder.prototype.appendInt32BE, 456
             ]),
             expectedOutput: [123, 456]
           },
           {
-            name: 'list32', type: 0xD0,
+            name: 'list32',
             value: buf([
-              builder.prototype.appendUInt32BE, 0xD,  builder.prototype.appendUInt32BE, 0x2,
+              0xD0,
+              builder.prototype.appendUInt32BE, 0xE, builder.prototype.appendUInt32BE, 0x2,
               0x71, builder.prototype.appendInt32BE, 123,
               0x71, builder.prototype.appendInt32BE, 456
             ]),
             expectedOutput: [123, 456]
           },
           {
-            name: 'array8', type: 0xE0,
-            value: buf([(10 + 1 + 1), 2, 0xA1,
+            name: 'array8',
+            value: buf([
+              0xE0,
+              (10 + 1 + 1), 2, 0xA1,
               4, builder.prototype.appendString, 'elt1',
               4, builder.prototype.appendString, 'elt2'
             ]),
             expectedOutput: ['elt1', 'elt2']
           },
           {
-            name: 'array32', type: 0xF0,
-            value: buf([builder.prototype.appendUInt32BE, (10 + 4 + 1),
+            name: 'array32',
+            value: buf([
+              0xF0,
+              builder.prototype.appendUInt32BE, (10 + 4 + 1),
               builder.prototype.appendUInt32BE, 2,
               0xA1,
               4, builder.prototype.appendString, 'elt1',
@@ -255,21 +394,23 @@ describe('Types', function() {
             ]),
             expectedOutput: ['elt1', 'elt2']
           },
-          { name: 'map8 (empty)', type: 0xC1, value: buf([0x1, 0x0]), expectedOutput: {} },
+          { name: 'map8 (empty)', value: buf([0xc1, 0x1, 0x0]), expectedOutput: {} },
           {
-            name: 'map8', type: 0xD1,
+            name: 'map8',
             value: buf([
-              builder.prototype.appendUInt32BE, 0x1c, builder.prototype.appendUInt32BE, 0x04,
+              0xc1,
+              0x19, 0x04,
               0xA1, 0x03, builder.prototype.appendString, 'foo',
-              0x71, builder.prototype.appendInt32BE, 123,
+              0x71, builder.prototype.appendInt32BE, 456,
               0xA1, 0x03, builder.prototype.appendString, 'bar',
               0x82, builder.prototype.appendDoubleBE, 45.6
             ]),
-            expectedOutput: { foo: 123, bar: 45.6 }
+            expectedOutput: { foo: 456, bar: 45.6 }
           },
           {
-            name: 'map32', type: 0xD1,
+            name: 'map32',
             value: buf([
+              0xd1,
               builder.prototype.appendUInt32BE, 0x1c, builder.prototype.appendUInt32BE, 0x02,
               0xA1, 0x03, builder.prototype.appendString, 'baz',
               0xD1, builder.prototype.appendUInt32BE, 0x0e, builder.prototype.appendUInt32BE, 0x02,


### PR DESCRIPTION
First shot at complete coverage for all currently supported scalar
and collection types. Switched to using ForcedType's for all the
encoding to make sure we're covering what we think we're covering.
There were a few changes made to tests, mostly where null values
were being encoded incorrectly as full values rather than their
<type>-null variant.