### PR TITLE
refactor(type-builders): always use encoding specific builders

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -335,7 +335,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'null',
       label: 'indicates an empty value',
-      builder: function(val, bufb) { bufb.appendUInt8(0x40); },
       encodings: [
         {
           code: 0x40,
@@ -366,7 +365,7 @@ Types.prototype._initTypesArray = function() {
           category: 'fixed',
           width: 0,
           label: 'the boolean value true',
-          builder: function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
+          builder: function(val, bufb) {},
           decoder: function(buf) { return true; }
         },
         {
@@ -374,7 +373,7 @@ Types.prototype._initTypesArray = function() {
           category: 'fixed',
           width: 0,
           label: 'the boolean value false',
-          builder: function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
+          builder: function(val, bufb) {},
           decoder: function(buf) { return false; }
         }
       ]
@@ -383,10 +382,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'ubyte',
       label: 'integer in the range 0 to 2^8 - 1 inclusive',
-      builder: function(val, bufb) {
-        bufb.appendUInt8(0x50);
-        bufb.appendUInt8(val);
-      },
       encodings: [
         {
           code: 0x50,
@@ -402,10 +397,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'ushort',
       label: 'integer in the range 0 to 2^16 - 1 inclusive',
-      builder: function(val, bufb) {
-        bufb.appendUInt8(0x60);
-        bufb.appendUInt16BE(val);
-      },
       encodings: [
         {
           code: 0x60,
@@ -422,15 +413,17 @@ Types.prototype._initTypesArray = function() {
       name: 'uint',
       label: 'integer in the range 0 to 2^32 - 1 inclusive',
       builder: function(val, bufb) {
+        var code;
         if (val === 0) {
-          bufb.appendUInt8(0x43);
+          code = 0x43;
         } else if (val < 0xFF) {
-          bufb.appendUInt8(0x52);
-          bufb.appendUInt8(val);
+          code = 0x52;
         } else {
-          bufb.appendUInt8(0x70);
-          bufb.appendUInt32BE(val);
+          code = 0x70;
         }
+
+        bufb.appendUInt8(code);
+        self.buildersByCode[code](val, bufb);
       },
       encodings: [
         {
@@ -454,7 +447,7 @@ Types.prototype._initTypesArray = function() {
           category: 'fixed',
           width: 0,
           label: 'the uint value 0',
-          builder: function(val, bufb) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
+          builder: function(val, bufb) {},
           decoder: function(buf) { return 0; }
         }
       ]
@@ -464,26 +457,22 @@ Types.prototype._initTypesArray = function() {
       name: 'ulong',
       label: 'integer in the range 0 to 2^64 - 1 inclusive',
       builder: function(val, bufb) {
+        var code = 0x80;
         if (val instanceof Int64 || val > 0xFF) {
           var check = (val instanceof Int64) ? val.toNumber(true) : val;
-
-          var code = 0x80;
           if (check === 0) {
             code = 0x44;
           } else if (check <= 0xFF) {
             code = 0x53;
           }
-
-          bufb.appendUInt8(code);
-          self.buildersByCode[code](val, bufb);
         } else if (val === 0) {
-          bufb.appendUInt8(0x44);
+          code = 0x44;
         } else if (val > 0 && val <= 0xFF) {
-          bufb.appendUInt8(0x53);
-          self.buildersByCode[0x53](val, bufb);
-        } else {
-          throw new Error('Invalid encoding type for 64-bit ulong value: ' + val);
+          code = 0x53;
         }
+
+        bufb.appendUInt8(code);
+        self.buildersByCode[code](val, bufb);
       },
       encodings: [
         {
@@ -529,10 +518,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'byte',
       label: 'integer in the range -(2^7) to 2^7 - 1 inclusive',
-      builder: function(val, bufb) {
-        bufb.appendUInt8(0x51);
-        bufb.appendInt8(val);
-      },
       encodings: [
         {
           code: 0x51,
@@ -548,10 +533,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'short',
       label: 'integer in the range -(2^15) to 2^15 - 1 inclusive',
-      builder: function(val, bufb) {
-        bufb.appendUInt8(0x61);
-        bufb.appendInt16BE(val);
-      },
       encodings: [
         {
           code: 0x61,
@@ -568,13 +549,9 @@ Types.prototype._initTypesArray = function() {
       name: 'int',
       label: 'integer in the range -(2^31) to 2^31 - 1 inclusive',
       builder: function(val, bufb) {
-        if (Math.abs(val) < 0x80) {
-          bufb.appendUInt8(0x54);
-          bufb.appendUInt8(val);
-        } else {
-          bufb.appendUInt8(0x71);
-          bufb.appendInt32BE(val);
-        }
+        var code = (Math.abs(val) < 0x80) ? 0x54 : 0x71;
+        bufb.appendUInt8(code);
+        self.buildersByCode[code](val, bufb);
       },
       encodings: [
         {
@@ -600,12 +577,8 @@ Types.prototype._initTypesArray = function() {
       name: 'long',
       label: 'integer in the range -(2^63) to 2^63 - 1 inclusive',
       builder: function(val, bufb) {
-        var code = 0x81;
         var check = (val instanceof Int64) ? val.toNumber(true) : val;
-        if (Math.abs(check) < 0x80) {
-          code = 0x55;
-        }
-
+        var code = (Math.abs(check) < 0x80) ? 0x55 : 0x81;
         bufb.appendUInt8(code);
         self.buildersByCode[code](val, bufb); // @todo Deal with Math.abs(val) < 0x7F cases
       },
@@ -646,10 +619,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'float',
       label: '32-bit floating point number (IEEE 754-2008 binary32)',
-      builder: function(val, bufb) {
-        bufb.appendUInt8(0x72);
-        bufb.appendFloatBE(val);
-      },
       encodings: [
         {
           code: 0x72,
@@ -665,10 +634,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'double',
       label: '64-bit floating point number (IEEE 754-2008 binary64)',
-      builder: function(val, bufb) {
-        bufb.appendUInt8(0x82);
-        bufb.appendDoubleBE(val);
-      },
       encodings: [
         {
           code: 0x82,
@@ -684,9 +649,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'decimal32',
       label: '32-bit decimal number (IEEE 754-2008 decimal32)',
-      builder: function(val, bufb) {
-        throw new exceptions.NotImplementedError('Decimal32');
-      },
       encodings: [
         {
           code: 0x74,
@@ -706,9 +668,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'decimal64',
       label: '64-bit decimal number (IEEE 754-2008 decimal64)',
-      builder: function(val, bufb) {
-        throw new exceptions.NotImplementedError('Decimal64');
-      },
       encodings: [
         {
           code: 0x84,
@@ -728,9 +687,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'decimal128',
       label: '128-bit decimal number (IEEE 754-2008 decimal128)',
-      builder: function(val, bufb) {
-        throw new exceptions.NotImplementedError('Decimal128');
-      },
       encodings: [
         {
           code: 0x94,
@@ -750,9 +706,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'char',
       label: 'a single unicode character',
-      builder: function(val, bufb) {
-        throw new exceptions.NotImplementedError('UTF32');
-      },
       encodings: [
         {
           code: 0x73,
@@ -772,10 +725,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'timestamp',
       label: 'an absolute point in time',
-      builder: function(val, bufb) {
-        bufb.appendUInt8(0x83);
-        self.buildersByCode[0x83](val, bufb);
-      },
       encodings: [
         {
           code: 0x83,
@@ -805,9 +754,6 @@ Types.prototype._initTypesArray = function() {
       class: 'primitive',
       name: 'uuid',
       label: 'a universally unique id as defined by RFC-4122 section 4.1.2',
-      builder: function(val, bufb) {
-        throw new exceptions.NotImplementedError('UUID');
-      },
       encodings: [
         {
           code: 0x98,
@@ -828,14 +774,9 @@ Types.prototype._initTypesArray = function() {
       name: 'binary',
       label: 'a sequence of octets',
       builder: function(val, bufb) {
-        if (val.length <= 0xFF) {
-          bufb.appendUInt8(0xA0);
-          bufb.appendUInt8(val.length);
-        } else {
-          bufb.appendUInt8(0xB0);
-          bufb.appendUInt32BE(val.length);
-        }
-        bufb.appendBuffer(val);
+        var code = (val.length <= 0xFF) ? 0xA0 : 0xB0;
+        bufb.appendUInt8(code);
+        self.buildersByCode[code](val, bufb);
       },
       encodings: [
         {
@@ -870,14 +811,10 @@ Types.prototype._initTypesArray = function() {
       label: 'a sequence of unicode characters',
       builder: function(val, bufb) {
         var encoded = new Buffer(val, 'utf8');
-        if (encoded.length <= 0xFF) {
-          bufb.appendUInt8(0xA1);
-          bufb.appendUInt8(encoded.length);
-        } else {
-          bufb.appendUInt8(0xB1);
-          bufb.appendUInt32BE(encoded.length);
-        }
-        bufb.appendBuffer(encoded);
+        var code = (encoded.length <= 0xFF) ? 0xA1 : 0xB1;
+
+        bufb.appendUInt8(code);
+        self.buildersByCode[code](encoded, bufb);
       },
       encodings: [
         {
@@ -919,14 +856,10 @@ Types.prototype._initTypesArray = function() {
       label: 'symbolic values from a constrained domain',
       builder: function(val, bufb) {
         var encoded = new Buffer(val, 'utf8');
-        if (encoded.length <= 0xFF) {
-          bufb.appendUInt8(0xA3);
-          bufb.appendUInt8(encoded.length);
-        } else {
-          bufb.appendUInt8(0xB3);
-          bufb.appendUInt32BE(encoded.length);
-        }
-        bufb.appendBuffer(encoded);
+        var code = (encoded.length <= 0xFF) ? 0xA3 : 0xB3;
+
+        bufb.appendUInt8(code);
+        self.buildersByCode[code](val, bufb);
       },
       encodings: [
         {
@@ -1058,7 +991,17 @@ Types.prototype._initEncodersDecoders = function() {
   var self = this;
   this.typesArray.forEach(function(type) {
     self.typesByName[type.name] = type;
-    self.builders[type.name] = type.builder;
+
+    if (!!type.builder) {
+      self.builders[type.name] = type.builder;
+    } else {
+      // default to first encoding
+      var typeCode = type.encodings[0].code;
+      self.builders[type.name] = function(val, bufb) {
+        bufb.appendUInt8(typeCode);
+        self.buildersByCode[typeCode](val, bufb);
+      };
+    }
 
     type.encodings.forEach(function(encoding) {
       self.decoders[encoding.code] = encoding.decoder;

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -31,11 +31,13 @@ describe('Types', function() {
 
     describe('primitives', function() {
       describe('scalar', function() {
+        var vbin32Buffer = [];
         var str32Utf8String;
         var sym32String;
         for (var i = 0; i < 500; ++i) {
           str32Utf8String += 'f';
           sym32String += 'a';
+          vbin32Buffer.push(0x01);
         }
 
         var str32Utf8StringExpectedBuffer = [
@@ -49,6 +51,11 @@ describe('Types', function() {
           builder.prototype.appendUInt32BE, sym32String.length,
           builder.prototype.appendString, sym32String
         ];
+
+        var vbin32ExpectedBuffer = [
+          0xb0,
+          builder.prototype.appendUInt32BE, 500,
+        ].concat(vbin32Buffer);
 
         [
           { name: 'null', value: null, expectedOutput: buf([0x40]) },
@@ -146,9 +153,16 @@ describe('Types', function() {
           //   ]),
           //   expectedOutput: 'some uuid'
           // },
-          // { name: 'vbin8', type: 0xa0, value: buf([0x10]), expectedOutput: new Buffer([0x10]) },
-          // { name: 'vin32', type: 0xb0, value: buf([0x01, 0x02, 0x03, 0x04]), expectedOutput: new Buffer([0x01, 0x02, 0x03, 0x04]) },
-
+          {
+            name: 'vbin8', type: 'binary',
+            value: new Buffer([0x10]),
+            expectedOutput: buf([0xa0, 0x01, 0x10])
+          },
+          {
+            name: 'vbin32', type: 'binary',
+            value: new Buffer(vbin32Buffer),
+            expectedOutput: buf(vbin32ExpectedBuffer)
+          },
           {
             name: 'str8-utf8', type: 'string',
             value: 'foo',
@@ -334,6 +348,11 @@ describe('Types', function() {
             name: 'str32-utf8',
             value: buf([0xb1, builder.prototype.appendUInt32BE, 3, builder.prototype.appendString, 'foo']),
             expectedOutput: 'foo'
+          },
+          {
+            name: 'str32-utf8 (empty)',
+            value: buf([0xb1, builder.prototype.appendUInt32BE, 0, builder.prototype.appendString, '']),
+            expectedOutput: ''
           },
           {
             name: 'sym8',


### PR DESCRIPTION
This change removes some needlessly duplicated code paths in the
types system by using builders defined on a per-encoding basis
directly. A futher optimization was added to use the first encoding
if a top-level builder was not defined.