### PR TITLE
test(types): full coverage for supported AMQP types

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -194,6 +194,11 @@ Codec.prototype.encode = function(val, buf, forceType) {
     return encoder(val, buf);
   }
 
+  if (!!forceType) {
+    encoder = types.builders[forceType] || types.buildersByCode[forceType];
+    return encoder(val, buf, this);
+  }
+
   switch (type) {
     case 'boolean':
       encoder = types.builders[forceType || 'boolean'];

--- a/lib/types.js
+++ b/lib/types.js
@@ -3,6 +3,7 @@
 var debug = require('debug')('amqp10-types'),
     builder = require('buffer-builder'),
     Int64 = require('node-int64'),
+    _ = require('lodash'),
 
     exceptions = require('./exceptions'),
     AMQPArray = require('./types/amqp_composites').Array,
@@ -95,12 +96,12 @@ Types.prototype._listBuilder = function(list, bufb, codec, width) {
 
   // Code, size, length, data
   if (width === 1 || (tempBuffer.length < 0xFF && list.length < 0xFF && width !== 4)) {
-    // Short lists
+    // list8
     if (!width) bufb.appendUInt8(0xC0);
     bufb.appendUInt8(tempBuffer.length + 1);
     bufb.appendUInt8(list.length);
   } else {
-    // Long lists
+    // list32
     if (!width) bufb.appendUInt8(0xD0);
     bufb.appendUInt32BE(tempBuffer.length + 4);
     bufb.appendUInt32BE(list.length);
@@ -231,13 +232,12 @@ Types.prototype._arrayDecoder = function(width, buffer, codec) {
  */
 Types.prototype._mapBuilder = function(map, bufb, codec, width) {
   if (typeof map !== 'object') {
-    throw new exceptions.NotImplementedError('Unsure how to encode non-object as array');
+    throw new exceptions.EncodingError('Unsure how to encode non-object as array');
   }
 
   if (Array.isArray(map)) {
-    throw new exceptions.NotImplementedError('Unsure how to encode array as map');
+    throw new exceptions.EncodingError('Unsure how to encode array as map');
   }
-
 
   var keys = Object.keys(map);
   if (!width && keys.length === 0) {
@@ -249,22 +249,21 @@ Types.prototype._mapBuilder = function(map, bufb, codec, width) {
 
   // Encode all elements into a temp buffer to allow us to front-load appropriate size and count.
   var tempBuilder = new builder();
-  for (var idx in keys) {
-    var curKey = keys[idx];
-    var curVal = map[curKey];
-    codec.encode(curKey, tempBuilder);
-    codec.encode(curVal, tempBuilder);
-  }
+  _.forEach(map, function(value, key) {
+    codec.encode(key, tempBuilder);
+    codec.encode(value, tempBuilder);
+  });
+
   var tempBuffer = tempBuilder.get();
 
   // Code, size, length, data
-  if (width === 1 || (width !== 4 && tempBuffer.length < 0xFF && map.length < 0xFF)) {
-    // Short lists
+  if (width === 1 || (width !== 4 && tempBuffer.length < 0xFF)) {
+    // map8
     if (!width) bufb.appendUInt8(0xC1);
     bufb.appendUInt8(tempBuffer.length + 1);
     bufb.appendUInt8(keys.length * 2);
   } else {
-    // Long lists
+    // map32
     if (!width) bufb.appendUInt8(0xD1);
     bufb.appendUInt32BE(tempBuffer.length + 4);
     bufb.appendUInt32BE(keys.length * 2);
@@ -396,10 +395,12 @@ Types.prototype._initTypesArray = function() {
           } else if (check <= 0xFF) {
             code = 0x53;
           }
-        } else if (val === 0) {
-          code = 0x44;
         } else if (val > 0 && val <= 0xFF) {
           code = 0x53;
+        } else if (val === 0) {
+          code = 0x44;
+        } else {
+          throw new exceptions.EncodingError('Invalid encoding type for ulong value: ' + val);
         }
 
         bufb.appendUInt8(code);
@@ -411,15 +412,13 @@ Types.prototype._initTypesArray = function() {
           builder: function(val, bufb) {
             if (val instanceof Int64) {
               bufb.appendBuffer(val.toBuffer(true));
-            } else if (typeof val === 'number') {
+            } else {
               if (val < 0xFFFFFFFF) {
                 bufb.appendUInt32BE(0x0);
                 bufb.appendUInt32BE(val);
               } else {
                 throw new exceptions.NotImplementedError('No int64 Number supported by buffer builder');
               }
-            } else {
-              throw new Error('Invalid encoding type for 64-bit value: ' + val);
             }
           },
           decoder: function(buf) { return new Int64(buf); }
@@ -499,7 +498,7 @@ Types.prototype._initTypesArray = function() {
                 throw new exceptions.NotImplementedError('buffer-builder does not support 64-bit int appending');
               }
             } else {
-              throw new Error('Invalid encoding type for 64-bit value: ' + val);
+              throw new exceptions.EncodingError('Invalid encoding type for 64-bit value: ' + val);
             }
           },
           decoder: function(buf) { return new Int64(buf); }
@@ -604,7 +603,7 @@ Types.prototype._initTypesArray = function() {
                 throw new exceptions.NotImplementedError('buffer-builder does not support 64-bit int appending');
               }
             } else {
-              throw new Error('Invalid encoding type for 64-bit value: ' + val);
+              throw new exceptions.EncodingError('Invalid encoding type for 64-bit value: ' + val);
             }
           },
           decoder: function(buf) { return new Int64(buf); }
@@ -693,17 +692,18 @@ Types.prototype._initTypesArray = function() {
     {
       name: 'symbol',
       builder: function(val, bufb) {
-        var encoded = new Buffer(val, 'utf8');
+        var encoded = (val instanceof AMQPSymbol) ?
+          new Buffer(val.toString(), 'utf8') : new Buffer(val, 'utf8');
         var code = (encoded.length <= 0xFF) ? 0xA3 : 0xB3;
 
         bufb.appendUInt8(code);
-        self.buildersByCode[code](val, bufb);
+        self.buildersByCode[code](encoded, bufb);
       },
       encodings: [
         {
           code: 0xa3,
           builder: function(val, bufb) {
-            var encoded = new Buffer(val, 'utf8');
+            var encoded = (val instanceof Buffer) ? val : new Buffer(val, 'utf8');
             bufb.appendUInt8(encoded.length);
             bufb.appendBuffer(encoded);
           },
@@ -732,7 +732,7 @@ Types.prototype._initTypesArray = function() {
       encodings: [
         {
           code: 0x45,
-          builder: function(val, bufb, codec) { throw new exceptions.NotImplementedError('Cannot build fixed zero-width values'); },
+          builder: function(val, bufb, codec) {},
           decoder: function(buf) { return []; }
         },
         {

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -13,7 +13,9 @@ var assert = require('assert'),
     ForcedType = require('../lib/types/forced_type'),
 
     AMQPSymbol = require('../lib/types/amqp_symbol'),
+    AMQPArray = require('../lib/types/amqp_composites').Array,
 
+    exceptions = require('../lib/exceptions'),
     tu = require('./testing_utils');
 
 var buf = tu.buildBuffer;
@@ -29,8 +31,59 @@ describe('Types', function() {
       });
     }
 
+    describe('errors', function() {
+      ['decimal32', 'decimal64', 'decimal128', 'char', 'uuid'].forEach(function(typeName) {
+        it('should error on unsupported type: ' + typeName, function() {
+          var buffer = new BufferBuilder();
+          var type = new ForcedType(typeName, 'some data');
+          expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.NotImplementedError);
+        });
+      });
+    });
+
     describe('primitives', function() {
       describe('scalar', function() {
+        describe('errors', function() {
+          it('should error encoding ulongs greater than 2^32 - 1', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('ulong', 4294967295);
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.NotImplementedError);
+          });
+
+          it('should error encoding ulongs of invalid type', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('ulong', 'giraffes');
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.EncodingError);
+          });
+
+
+          it('should error encoding longs greater than 2^32 - 1', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('long', 4294967295);
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.NotImplementedError);
+          });
+
+          it('should error encoding longs of invalid type', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('long', 'elephants');
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.EncodingError);
+          });
+
+          it('should error encoding timestamps greater than 2^32 - 1', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('timestamp', 4294967295);
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.NotImplementedError);
+          });
+
+          it('should error encoding timestamps of invalid type', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('timestamp', 'turtles');
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.EncodingError);
+          });
+
+        });
+
+
         var vbin32Buffer = [];
         var str32Utf8String;
         var sym32String;
@@ -60,7 +113,11 @@ describe('Types', function() {
         [
           { name: 'null', value: null, expectedOutput: buf([0x40]) },
           { name: 'true', type: 'boolean', value: true, expectedOutput: buf([0x41]) },
+          { name: 'true (by code)', type: 0x41, value: true, expectedOutput: buf([]) },
           { name: 'false', type: 'boolean', value: false, expectedOutput: buf([0x42]) },
+          { name: 'false (by code)', type: 0x42, value: false, expectedOutput: buf([]) },
+          { name: 'boolean (truth by code)', type: 0x56, value: true, expectedOutput: buf([0x01]) },
+          { name: 'boolean (false by code)', type: 0x56, value: false, expectedOutput: buf([0x00]) },
           { name: 'ubyte', value: 1, expectedOutput: buf([0x50, 0x01]) },
           { name: 'ushort', value: 1, expectedOutput: buf([0x60, 0x00, 0x01]) },
 
@@ -92,8 +149,13 @@ describe('Types', function() {
             expectedOutput: buf([0x53, 0x01])
           },
           {
-            name: 'ulong0', type: 'ulong',
+            name: 'ulong0 (int64)', type: 'ulong',
             value: new Int64(0x00000000, 0x00000000),
+            expectedOutput: buf([0x44])
+          },
+          {
+            name: 'ulong0', type: 'ulong',
+            value: 0,
             expectedOutput: buf([0x44])
           },
           { name: 'byte', value: 1, expectedOutput: buf([0x51, 0x01]) },
@@ -124,7 +186,6 @@ describe('Types', function() {
             name: 'double', value: 123.45,
             expectedOutput: buf([0x82, builder.prototype.appendDoubleBE, 123.45])
           },
-
           // { name: 'decimal32', type: 0x74, value: buf([0x00, 0x01, 0x00, 0x01]), expectedOutput: 1.1 },
           // {
           //   name: 'decimal64', type: 0x84,
@@ -141,11 +202,6 @@ describe('Types', function() {
           // },
           // { name: 'utf32 (char)', type: 0x73, value: buf([0x24]), expectedOutput: '$' },
           // {
-          //   name: 'ms64 (timestamp)', type: 0x83,
-          //   value: buf([0x00, 0x00, 0x00, 0x00, 0x55, 0x10, 0x7B, 0x38]),
-          //   expectedOutput: new Date(1427143480)
-          // },
-          // {
           //   name: 'uuid', type: 0x98,
           //   value: buf([
           //     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
@@ -153,6 +209,16 @@ describe('Types', function() {
           //   ]),
           //   expectedOutput: 'some uuid'
           // },
+          {
+            name: 'ms64 (timestamp int64)', type: 'timestamp',
+            value: new Int64(1427143480),
+            expectedOutput: buf([0x83, 0x00, 0x00, 0x00, 0x00, 0x55, 0x10, 0x7B, 0x38])
+          },
+          {
+            name: 'ms64 (timestamp)', type: 'timestamp',
+            value: 1427143480,
+            expectedOutput: buf([0x83, 0x00, 0x00, 0x00, 0x00, 0x55, 0x10, 0x7B, 0x38])
+          },
           {
             name: 'vbin8', type: 'binary',
             value: new Buffer([0x10]),
@@ -194,10 +260,102 @@ describe('Types', function() {
       });
 
       describe('collection', function() {
+        describe('errors', function() {
+          it('should error trying to build an array of non AMQPArray', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('array', []);
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.EncodingError);
+          });
+
+          it('should error trying to build an AMQPArray with invalid types', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('array', new AMQPArray('invalidType', []));
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.EncodingError);
+          });
+
+          it('should error trying to build a list with non arrays', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('list', {});
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.EncodingError);
+          });
+
+          it('should error trying to build a map with non object', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('map', 'dogs');
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.EncodingError);
+          });
+
+          it('should error trying to build a map from an array', function() {
+            var buffer = new BufferBuilder();
+            var type = new ForcedType('map', ['dogs']);
+            expect(function() { codec.encode(type, buffer); }).to.throw(exceptions.EncodingError);
+          });
+        });
+
+        var array32 = [];
+        var array32Buffer = [];
+        var list32Buffer = [];
+        var map32 = {};
+        var map32Buffer = [];
+        for (var i = 0; i < 256; ++i) {
+          array32.push(1);
+          array32Buffer.push(0x01);
+
+          list32Buffer.push(0x54);
+          list32Buffer.push(0x01);
+
+          var key = 'elt' + (100 +i);
+          map32[key] = 456;
+          map32Buffer = map32Buffer.concat([
+            0xA1, 0x06, builder.prototype.appendString, key,
+            0x71, builder.prototype.appendInt32BE, 456,
+          ]);
+        }
+
+        var array32ExpectedBuffer = [
+          0xF0,
+          builder.prototype.appendUInt32BE, 261, builder.prototype.appendUInt32BE, 256,
+          0x54
+        ].concat(array32Buffer);
+
+        var list32 = array32;
+        var list32ExpectedBuffer = [
+          0xd0,
+          builder.prototype.appendUInt32BE, 516, builder.prototype.appendUInt32BE, 256,
+        ].concat(list32Buffer);
+
+        var map32ExpectedBuffer = [
+          0xD1,
+          builder.prototype.appendUInt32BE, 3332, builder.prototype.appendUInt32BE, 512,
+        ].concat(map32Buffer);
+
         [
-          { name: 'list(empty)', type: 'list', value: [], expectedOutput: buf([0x45]) },
+          { name: 'array8 (empty)', type: 'array', value: new AMQPArray([], 0x54), expectedOutput: buf([0x40]) },
           {
-            name: 'list', value: [456, 789],
+            name: 'array8', type: 'array',
+            value: new AMQPArray([1, 2, 3], 0x54),
+            expectedOutput: buf([0xe0, 0x05, 0x03, 0x54, 0x01, 0x02, 0x03])
+          },
+          {
+            name: 'array8 (by code)', type: 0xe0,
+            value: new AMQPArray([1, 2, 3], 0x54),
+            expectedOutput: buf([0x05, 0x03, 0x54, 0x01, 0x02, 0x03])
+          },
+          {
+            name: 'array32', type: 'array',
+            value: new AMQPArray(array32, 0x54),
+            expectedOutput: array32ExpectedBuffer
+          },
+          {
+            name: 'array32 (by code)', type: 0xf0,
+            value: new AMQPArray(array32, 0x54),
+            expectedOutput: array32ExpectedBuffer.slice(1, array32ExpectedBuffer.length)
+          },
+          { name: 'list (empty)', type: 'list', value: [], expectedOutput: buf([0x45]) },
+          { name: 'list (empty by code)', type: 0x45, value: [], expectedOutput: buf([]) },
+          {
+            name: 'list8', type: 'list',
+            value: [456, 789],
             expectedOutput: buf([
               0xC0,
               0xB, 0x2,
@@ -205,12 +363,27 @@ describe('Types', function() {
               0x71, builder.prototype.appendInt32BE, 789
             ])
           },
-          { name: 'map(empty)', type: 'map', value: {}, expectedOutput: buf([0xc1, 0x1, 0x0]) },
           {
-            name: 'map', value: { foo: 456, bar: 45.6 },
+            name: 'list8 (by code)', type: 0xC0,
+            value: [456, 789],
             expectedOutput: buf([
-              0xD1,
-              builder.prototype.appendUInt32BE, 0x1c, builder.prototype.appendUInt32BE, 0x04,
+              0xB, 0x2,
+              0x71, builder.prototype.appendInt32BE, 456,
+              0x71, builder.prototype.appendInt32BE, 789
+            ])
+          },
+          { name: 'list32', type: 'list', value: list32, expectedOutput: list32ExpectedBuffer },
+          {
+            name: 'list32 (by code)', type: 0xd0, value: list32,
+            expectedOutput: list32ExpectedBuffer.slice(1, list32ExpectedBuffer.length)
+          },
+          { name: 'map8 (empty)', type: 'map', value: {}, expectedOutput: buf([0xc1, 0x1, 0x0]) },
+          {
+            name: 'map8', type: 'map',
+            value: { foo: 456, bar: 45.6 },
+            expectedOutput: buf([
+              0xC1,
+              0x19, 0x04,
               0xA1, 0x03, builder.prototype.appendString, 'foo',
               0x71, builder.prototype.appendInt32BE, 456,
               0xA1, 0x03, builder.prototype.appendString, 'bar',
@@ -218,16 +391,34 @@ describe('Types', function() {
             ])
           },
           {
-            name: 'map(nested)', type: 'map', value: { baz: { zap: 'bop' } },
+            name: 'map8 (by code)', type: 0xC1,
+            value: { foo: 456, bar: 45.6 },
             expectedOutput: buf([
-              0xD1,
-              builder.prototype.appendUInt32BE, 0x1c, builder.prototype.appendUInt32BE, 0x02,
+              0x19, 0x04,
+              0xA1, 0x03, builder.prototype.appendString, 'foo',
+              0x71, builder.prototype.appendInt32BE, 456,
+              0xA1, 0x03, builder.prototype.appendString, 'bar',
+              0x82, builder.prototype.appendDoubleBE, 45.6
+            ])
+          },
+          {
+            name: 'map8 (nested)', type: 'map', value: { baz: { zap: 'bop' } },
+            expectedOutput: buf([
+              0xC1,
+              0x13, 0x02,
               0xA1, 0x03, builder.prototype.appendString, 'baz',
-              0xD1, builder.prototype.appendUInt32BE, 0x0e, builder.prototype.appendUInt32BE, 0x02,
+              0xC1,
+              0x0b, 0x02,
               0xA1, 0x03, builder.prototype.appendString, 'zap',
               0xA1, 0x03, builder.prototype.appendString, 'bop'
             ])
+          },
+          { name: 'map32', type: 'map', value: map32, expectedOutput: map32ExpectedBuffer },
+          {
+            name: 'map32 (by code)', type: 0xD1, value: map32,
+            expectedOutput: map32ExpectedBuffer.slice(1, map32ExpectedBuffer.length)
           }
+
         ].forEach(testEncoding);
       });
     });
@@ -245,7 +436,26 @@ describe('Types', function() {
       });
     }
 
+    describe('errors', function() {
+      [
+        { name: 'char', value: buf([0x73, 0x00, 0x00, 0x00, 0x00]) },
+        { name: 'decimal32', value: buf([0x74, 0x00, 0x00, 0x00, 0x00]) },
+        { name: 'decimal64', value: buf([0x84, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]) },
+        { name: 'decimal128' , value: buf([0x94, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]) },
+        { name: 'uuid', value: buf([0x98, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]) }
+      ].forEach(function(type) {
+        it('should error on unsupported type: ' + type.name, function() {
+          expect(function() { codec.decode(type.value, 0); }).to.throw(exceptions.NotImplementedError);
+        });
+      });
+    });
+
     describe('primitives', function() {
+      describe('errors', function() {
+
+      });
+
+
       describe('scalar', function() {
         [
           { name: 'null', value: buf([0x40]), expectedOutput: null },
@@ -367,6 +577,30 @@ describe('Types', function() {
       });
 
       describe('collection', function() {
+        describe('errors', function() {
+          it('should error trying to decode an array with invalid types', function() {
+            var data = buf([
+              0xE0,
+              (10 + 1 + 1), 2, 0xf1,
+              4, builder.prototype.appendString, 'elt1',
+              4, builder.prototype.appendString, 'elt2',
+            ]);
+
+            expect(function() { codec.decode(data); }).to.throw(exceptions.MalformedPayloadError);
+          });
+
+          it('should error trying to decode an array with non uniform types', function() {
+            var data = buf([
+              0xE0,
+              (10 + 1 + 1), 2, 0xA1,
+              4, builder.prototype.appendString, 'elt1',
+              0x71, builder.prototype.appendInt32BE, 456
+            ]);
+
+            expect(function() { codec.decode(data); }).to.throw(exceptions.MalformedPayloadError);
+          });
+        });
+
         [
           { name: 'list0', value: buf([0x45]), expectedOutput: [] },
           {


### PR DESCRIPTION
This brings our coverage for supported AMQP types to 100%. Because
forced types were not properly implemented in codec.encode, we will
probably lose a certain amount of overall coverage (since it will
not test all the non-forced branches anymore), but that can easily
be reimplemented.