### PR TITLE
fix(message-properties): add missing field and correct null values

### DIFF
--- a/lib/types/message.js
+++ b/lib/types/message.js
@@ -180,15 +180,19 @@ Properties.prototype.getValue = function() {
     to: u.orNull(self.to),
     subject: u.orNull(self.subject),
     replyTo: u.orNull(self.replyTo),
+    correlationId: u.orNull(self.correlationId),
     contentType: u.orNull(self.contentType),
     contentEncoding: u.orNull(self.contentEncoding),
-    absoluteExpiryTime: new ForcedType('timestamp', self.absoluteExpiryTime),
-    creationTime: new ForcedType('timestamp', self.creationTime),
+    absoluteExpiryTime: (self.absoluteExpiryTime === undefined) ? null : new ForcedType('timestamp', self.absoluteExpiryTime),
+    creationTime: (self.creationTime === undefined) ? null : new ForcedType('timestamp', self.creationTime),
     groupId: u.orNull(self.groupId),
-    groupSequence: new ForcedType('uint', self.groupSequence),
+    groupSequence: (self.groupSequence === undefined) ? null : new ForcedType('uint', self.groupSequence),
     replyToGroupId: u.orNull(self.replyToGroupId),
-    encodeOrdering: ['messageId', 'userId', 'to', 'subject', 'replyTo', 'contentType', 'contentEncoding',
-      'absoluteExpiryTime', 'creationTime', 'groupId', 'groupSequence', 'replyToGroupId']
+    encodeOrdering: [
+      'messageId', 'userId', 'to', 'subject', 'replyTo', 'correlationId',
+      'contentType', 'contentEncoding', 'absoluteExpiryTime', 'creationTime',
+      'groupId', 'groupSequence', 'replyToGroupId'
+    ]
   };
 };
 


### PR DESCRIPTION
Message.Properties omitted the "correlation-id" field, and did not
properly handle undefined values for the following fields:
  - absolute-expiry-time
  - creation-time
  - group-sequence