### PR TITLE
new breaking changes

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -223,31 +223,33 @@ AMQPClient.prototype.connect = function(url, cb) {
 
 
 /**
- * Sends the given message, with the given annotations, to the given target.
+ * Sends the given message, with the given options, to the given target.
  *
  * @param {*} msg               Message to send.  Will be encoded using sender link policy's encoder.
  * @param {string} [target]     Target to send to.  If not set, will use default queue from uri used to connect.
- * @param {*} [annotations]     Annotations for the message, if any.  See AMQP spec for details, and server for specific
+ * @param {*} [options]         An object of options to attach to the message including: annotations, properties,
+                                and application properties
+ * @param options.annotations   Annotations for the message, if any.  See AMQP spec for details, and server for specific
  *                               annotations that might be relevant (e.g. x-opt-partition-key on EventHub).  If node-amqp-encoder'd
  *                               map is given, it will be translated to appropriate internal types.  Simple maps will be converted
  *                               to AMQP Fields type as defined in the spec.
  * @param {function} cb         Callback, by default called when settled disposition is received from target, with (error, delivery-state).
  *                              However, setting the sender callback policy to OnSent can change when this is called to as soon as the packets go out.
  */
-AMQPClient.prototype.send = function(msg, target, annotations, cb) {
+AMQPClient.prototype.send = function(msg, target, options, cb) {
 
   var self = this;
   if (cb === undefined) {
-    if (annotations === undefined) {
+    if (options === undefined) {
       cb = target;
       target = undefined;
     } else {
       if (typeof target === 'string') {
-        cb = annotations;
-        annotations = undefined;
+        cb = options;
+        options = undefined;
       } else {
-        cb = annotations;
-        annotations = target;
+        cb = options;
+        options = target;
         target = undefined;
       }
     }
@@ -272,13 +274,21 @@ AMQPClient.prototype.send = function(msg, target, annotations, cb) {
   if (this._attaching[linkName] === undefined) this._attaching[linkName] = false;
 
   var message = new M.Message();
-  if (annotations) {
-    // Convert encoded values
-    if (annotations instanceof Array && annotations[0] === 'map') {
-      annotations = AMQPClient.adapters.Translator(annotations);
+  if (options) {
+    if (options.annotations) {
+      message.annotations = new M.Annotations(options.annotations);
     }
-    message.annotations = new M.Annotations(annotations);
+
+    if (options.properties) {
+      message.properties = new M.Properties(options.properties);
+    }
+
+    if (options.applicationProperties) {
+      message.applicationProperties =
+        new M.ApplicationProperties(options.applicationProperties);
+    }
   }
+
   var enc = this.policy.senderLinkPolicy.encoder;
   message.body.push(enc ? enc(msg) : msg);
   var curId = self._sendMsgId++;
@@ -421,7 +431,7 @@ AMQPClient.prototype.send = function(msg, target, annotations, cb) {
  * @param {*} [filter]          Filter used in connecting to the source.  See AMQP spec for details, and your server's documentation
  *                               for possible values.  node-amqp-encoder'd maps will be translated, and simple maps will be converted
  *                               to AMQP Fields type as defined in the spec.
- * @param {function} cb         Callback to invoke on every receipt.  Called with (error, payload, annotations).
+ * @param {function} cb         Callback to invoke on every receipt.  Called with (error, payload, options).
  */
 AMQPClient.prototype.receive = function(source, filter, cb) {
   var self = this;
@@ -476,17 +486,23 @@ AMQPClient.prototype.receive = function(source, filter, cb) {
             });
           }
         });
+
         l.on(Link.MessageReceived, function(m) {
           var payload = m.body[0];
           var decoded = l.policy.decoder ? l.policy.decoder(payload) : payload;
           debug('Received ' + decoded + ' from ' + source);
           var cbs = self._onReceipt[linkName];
           if (cbs && cbs.length > 0) {
+            var options = {};
+            if (m.annotations) options.annotations = m.annotations;
+            if (m.properties) options.properties = m.properties;
+
             cbs.forEach(function (cb) {
-              cb(null, decoded, m.annotations);
+              cb(null, decoded, options);
             });
           }
         });
+
         l.on(Link.Detached, function(details) {
           debug('Link detached: ' + (details ? details.error : 'No details'));
           self._attached[linkName] = undefined;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  Client: require('./amqp_client')
+};

--- a/lib/types/message.js
+++ b/lib/types/message.js
@@ -160,8 +160,10 @@ Properties.fromDescribedType = function(describedType) {
     to: propertiesArr[idx++],
     subject: propertiesArr[idx++],
     replyTo: propertiesArr[idx++],
-    correlationId: propertiesArr[idx++].contents,     // AMQPSymbol
-    contentType: propertiesArr[idx++].contents,       // AMQPSymbol
+    correlationId:
+      (typeof propertiesArr[idx++] === AMQPSymbol) ? propertiesArr[idx++].contents : propertiesArr[idx++],
+    contentType:
+      (typeof propertiesArr[idx++] === AMQPSymbol) ? propertiesArr[idx++].contents : propertiesArr[idx++],
     contentEncoding: propertiesArr[idx++],
     absoluteExpiryTime: propertiesArr[idx++],
     creationTime: propertiesArr[idx++],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqp10",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Native AMQP-1.0 client for node.js",
   "main": "./lib",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "amqp10",
   "version": "1.0.3",
   "description": "Native AMQP-1.0 client for node.js",
-  "main": "./lib/amqp_client.js",
+  "main": "./lib",
   "engines": {
     "node": ">= 0.8"
   },


### PR DESCRIPTION
* ```require('amqp10');``` now returns an object that currently contains only ```Client```, opening up for a future where we might want to export other internal parts of the library. This is a breaking change as all users will need to modify their code to read: ```var AMQPClient = require('amqp10').Client;```

* Message properties have been exposed in both send and receive methods, allowing finer control over the metadata associated with messages

* A small fix was added for the previously modified Properties class. Since the ctor is being used for coding and encoding, sometimes the content-type and content-encoding fields might not actually be AMQPSymbols, and therefore accessing 'contents' of those values will throw an error. 