### PR TITLE
refactor(connect): remove side-effecty connect calls

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -64,16 +64,9 @@ var EventEmitter = require('events').EventEmitter,
  * instantiation to sending messages.
  *
  * @param {PolicyBase} [policy]     Policy to use for connection, sessions, links, etc.  Defaults to PolicyBase.
- * @param {string} [uri]            If provided, must provide cb.  Will attempt connection, set default queue.
- * @param {function} [cb]           If provided, must provide uri.  Will attempt connection and call cb when established/failed.
  * @constructor
  */
-function AMQPClient(policy, uri, cb) {
-  if (typeof policy === 'string') {
-    cb = uri;
-    uri = policy;
-    policy = undefined;
-  }
+function AMQPClient(policy) {
   // Make a protective copy
   this._originalPolicy = u.deepMerge(policy || PolicyBase);
   this.policy = u.deepMerge(this._originalPolicy);
@@ -87,10 +80,6 @@ function AMQPClient(policy, uri, cb) {
   this._onReceipt = {};
   this._pendingSends = {};
   this._unsettledSends = {};
-
-  if (uri) {
-    this.connect(uri, cb);
-  }
 }
 util.inherits(AMQPClient, EventEmitter);
 
@@ -237,6 +226,7 @@ AMQPClient.prototype.connect = function(url, cb) {
  *                              However, setting the sender callback policy to OnSent can change when this is called to as soon as the packets go out.
  */
 AMQPClient.prototype.send = function(msg, target, options, cb) {
+  if (!this._connection) { throw new Error('Must connect before sending'); }
 
   var self = this;
   if (cb === undefined) {
@@ -257,14 +247,6 @@ AMQPClient.prototype.send = function(msg, target, options, cb) {
 
   if (!target) {
     target = this._defaultQueue;
-  }
-
-  // If given full address, pull out target first to avoid leaking credentials in error messages containing linkName.
-  var rootUri;
-  if (target && target.toLowerCase().lastIndexOf('amqp', 0) === 0) {
-    var address = u.parseAddress(target);
-    rootUri = address.rootUri;
-    target = address.path.substring(1);
   }
 
   var linkName = target + '_TX';
@@ -382,35 +364,10 @@ AMQPClient.prototype.send = function(msg, target, options, cb) {
 
   this._reattach[linkName] = attach;
 
-  // If we're given a full address, ensure we're connected first.
-  if (rootUri) {
-    if (!this._attached[linkName]) {
-      if (!this._connection) {
-        this._attaching[linkName] = true;
-        this._pendingSends[linkName].push(sender);
-
-        // If we're not connected yet, connect, then callback into ourselves.
-        this.connect(rootUri, function(conn_err) {
-          if (conn_err) {
-            cb(conn_err);
-          } else {
-            attach();
-          }
-        });
-        return;
-      } else {
-        // We must've dropped our link, but connection is still active.  Try and re-establish.
-        self._pendingSends[linkName].push(sender);
-        attach();
-        return;
-      }
-    }
-  } else {
-    if (!this._attached[linkName]) {
-      self._pendingSends[linkName].push(sender);
-      attach();
-      return;
-    }
+  if (!this._attached[linkName]) {
+    self._pendingSends[linkName].push(sender);
+    attach();
+    return;
   }
 
   var link = this._attached[linkName];
@@ -434,6 +391,8 @@ AMQPClient.prototype.send = function(msg, target, options, cb) {
  * @param {function} cb         Callback to invoke on every receipt.  Called with (error, payload, options).
  */
 AMQPClient.prototype.receive = function(source, filter, cb) {
+  if (!this._connection) { throw new Error('Must connect before receiving'); }
+
   var self = this;
   if (cb === undefined) {
     if (typeof source === 'function') {
@@ -452,14 +411,6 @@ AMQPClient.prototype.receive = function(source, filter, cb) {
   if (filter && filter instanceof Array && filter[0] === 'map') {
     // Convert encoded values
     filter = AMQPClient.adapters.Translator(filter);
-  }
-
-  // If given full address, pull out source first to avoid leaking credentials in error messages containing linkName.
-  var rootUri;
-  if (source && source.toLowerCase().lastIndexOf('amqp', 0) === 0) {
-    var address = u.parseAddress(source);
-    rootUri = address.rootUri;
-    source = address.path.substring(1);
   }
 
   var linkName = source + '_RX';
@@ -538,27 +489,8 @@ AMQPClient.prototype.receive = function(source, filter, cb) {
 
   this._reattach[linkName] = attach;
 
-  // If we're given a full address, ensure we're connected first.
-  if (rootUri) {
-    if (!this._attached[linkName]) {
-      if (!this._connection) {
-        // If we're not connected yet, connect, then callback into ourselves.
-        this.connect(rootUri, function(conn_err) {
-          if (conn_err) {
-            cb(conn_err);
-          } else {
-            attach();
-          }
-        });
-      } else {
-        // We must've dropped our link, but connection is still active.  Try and re-establish.
-        attach();
-      }
-    }
-  } else {
-    if (!this._attached[linkName]) {
-      attach();
-    }
+  if (!this._attached[linkName]) {
+    attach();
   }
 };
 


### PR DESCRIPTION
There were a number of locations where connect was called in the
event that a user had not previously connected. As this is prone
to error, it's being removed in favor forcing users to call connect
explicitly.