### PR TITLE
fix(message-properties): properly convert symbols from described

### DIFF
--- a/lib/types/message.js
+++ b/lib/types/message.js
@@ -160,10 +160,8 @@ Properties.fromDescribedType = function(describedType) {
     to: propertiesArr[idx++],
     subject: propertiesArr[idx++],
     replyTo: propertiesArr[idx++],
-    correlationId:
-      (typeof propertiesArr[idx++] === AMQPSymbol) ? propertiesArr[idx++].contents : propertiesArr[idx++],
-    contentType:
-      (typeof propertiesArr[idx++] === AMQPSymbol) ? propertiesArr[idx++].contents : propertiesArr[idx++],
+    correlationId: propertiesArr[idx++],
+    contentType: propertiesArr[idx++],
     contentEncoding: propertiesArr[idx++],
     absoluteExpiryTime: propertiesArr[idx++],
     creationTime: propertiesArr[idx++],
@@ -171,6 +169,12 @@ Properties.fromDescribedType = function(describedType) {
     groupSequence: propertiesArr[idx++],
     replyToGroupId: propertiesArr[idx++]
   };
+
+  ['contentType', 'contentEncoding'].forEach(function(option) {
+    if (typeof options[option] === AMQPSymbol)
+      options[option] = options[option].contents;
+  });
+
   return new Properties(options);
 };
 


### PR DESCRIPTION
the previous "fix" for this was incorrectly incrementing the array position when checking for an incoming AMQPSymbol