### PR TITLE
fix(cached-receivers): resolve receiver links that already exist

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -426,16 +426,33 @@ AMQPClient.prototype.createReceiver = function(source, filter, cb) {
   }
 
   var linkName = source + '_RX';
-  // Set some initial state for the link.
-  if (this._onReceipt[linkName] === undefined) this._onReceipt[linkName] = [];
-  if (this._attached[linkName] === undefined) this._attached[linkName] = null;
-  if (this._attaching[linkName] === undefined) this._attaching[linkName] = false;
+  if (this._attaching[linkName]) {
+    return new Promise(function(resolve, reject) {
+      var attachingListner = function(link) {
+        if (link.name === linkName) {
+          self.removeListener(AMQPClient.LinkAttached, attachingListner);
+          resolve(link);
+        }
+      };
 
-  this._onReceipt[linkName].push(cb);
-  if (this._attaching[linkName] || this._attached[linkName]) return;
+      self.on(AMQPClient.LinkAttached, attachingListner);
+    });
+  }
 
   return new Promise(function(resolve, reject) {
+    if (self._attached[linkName])
+      return resolve(self._attached[linkName]);
+
+    // otherwise create the link, and set initial state
+    if (self._onReceipt[linkName] === undefined) self._onReceipt[linkName] = [];
+    if (self._attached[linkName] === undefined) self._attached[linkName] = null;
+    if (self._attaching[linkName] === undefined) self._attaching[linkName] = false;
+
+    self._onReceipt[linkName].push(cb);
+
     var attach = function() {
+      self._attaching[linkName] = true;
+
       var onAttached = function(l) {
         if (l.name === linkName) {
           debug('Receiver link ' + linkName + ' attached');
@@ -479,6 +496,7 @@ AMQPClient.prototype.createReceiver = function(source, filter, cb) {
       };
 
       self.on(AMQPClient.LinkAttached, onAttached);
+
       if (self._session) {
         var linkPolicy = u.deepMerge({
           options: {


### PR DESCRIPTION
Previously we were not resolving attempts to create a receiver with
existing links that were either in the process of attaching or
attached.