### PR TITLE
fix(link-attach): fix attachment messaging issues due to deps

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -105,7 +105,10 @@ Link.prototype.attachReceived = function(attachFrame) {
   }
   debug('Rx attach CH=[' + this.session.channel + '=>' + attachFrame.channel + '], Handle=[' + this.handle + '=>' + attachFrame.handle + ']');
   this.attached = true;
-  this.session.emit(Session.LinkAttached, this);
+
+  // @todo: Session should listen for Link.Attached
+  this.session._linkAttached(this);
+
   this._checkCredit();
 };
 
@@ -216,7 +219,9 @@ Link.prototype._detached = function(frame) {
   this.session._allocatedHandles[this.policy.options.handle] = undefined;
   this.attached = false;
   this.emit(Link.Detached, { closed: frame.closed, error: frame.error });
-  this.session.emit(Session.LinkDetached, this);
+
+  // @todo: Session should listen for Link.Detached
+  this.session._linkDetached(this);
 };
 
 module.exports = Link;

--- a/lib/session.js
+++ b/lib/session.js
@@ -208,6 +208,13 @@ Session.prototype.attachLink = function(linkPolicy) {
   return newLink;
 };
 
+Session.prototype._linkAttached = function(link) {
+  this.emit(Session.LinkAttached, link);
+};
+
+Session.prototype._linkDetached = function(link) {
+  this.emit(Session.LinkDetached, link);
+};
 
 /**
  *


### PR DESCRIPTION
Circular dependencies between Link and Session were causing the
objects to be imported incompletely. As a stopgap for a proper
solution where Session listens for Link events properly, two
private methods are used to route the attachment signalling.