### PR TITLE
fix(multiple-receivers): register callback when attaching

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -440,6 +440,8 @@ AMQPClient.prototype.createReceiver = function(source, filter, cb) {
 
   var linkName = source + '_RX';
   if (this._attaching[linkName]) {
+    self._onReceipt[linkName].push(cb);
+
     return new Promise(function(resolve, reject) {
       var attachingListener = function(link) {
         if (link.name === linkName) {


### PR DESCRIPTION
Bug missed in the promisification of createReceiver where callbacks
passed in with createReceiver during attachment were not retained.