### PR TITLE
Event cleanup + EventEmitter leak fixes

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -85,13 +85,13 @@ function AMQPClient(policy) {
 util.inherits(AMQPClient, EventEmitter);
 
 // Events - mostly for internal use.
-AMQPClient.ErrorReceived = 'ErrorReceived'; // Called with error
-AMQPClient.ConnectionOpened = 'Connection.Opened';
-AMQPClient.SessionMapped = 'Session.Mapped';
-AMQPClient.LinkAttached = 'Link.Attached'; // Called with link
-AMQPClient.LinkDetached = 'Link.Detached'; // Called with link
-AMQPClient.SessionUnmapped = 'Session.Unmapped';
-AMQPClient.ConnectionClosed = 'Connection.Closed';
+AMQPClient.ErrorReceived = 'client:errorReceived'; // Called with error
+AMQPClient.ConnectionOpened = 'connection:opened';
+AMQPClient.SessionMapped = 'session:mapped';
+AMQPClient.LinkAttached = 'link:attached'; // Called with link
+AMQPClient.LinkDetached = 'link:detached'; // Called with link
+AMQPClient.SessionUnmapped = 'session:unmapped';
+AMQPClient.ConnectionClosed = 'connection:closed';
 
 
 /**

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -304,13 +304,17 @@ function Connection(connectPolicy) {
 util.inherits(Connection, EventEmitter);
 
 // Events
-Connection.Connected = 'connected';
-Connection.Disconnected = 'disconnected';
-// On receipt of a frame not handled internally (e.g. not a BEGIN/CLOSE/SASL).  Provides received frame as an argument.
-Connection.FrameReceived = 'rxFrame';
-// Since 'error' events are "special" in Node (as in halt-the-process special), using a custom event for errors
-// we receive from the other endpoint.  Provides received AMQPError as an argument.
-Connection.ErrorReceived = 'rxError';
+Connection.Connected = 'connection:connected';
+Connection.Disconnected = 'connection:disconnected';
+
+// On receipt of a frame not handled internally (e.g. not a BEGIN/CLOSE/SASL).
+// Provides received frame as an argument.
+Connection.FrameReceived = 'connection:frameReceived';
+
+// Since 'error' events are "special" in Node (as in halt-the-process special),
+// using a custom event for errors we receive from the other endpoint. Provides
+// received AMQPError as an argument.
+Connection.ErrorReceived = 'connection:errorReceived';
 
 
 /**

--- a/lib/link.js
+++ b/lib/link.js
@@ -185,12 +185,11 @@ Link.prototype.addCredits = function(credits, flowOptions) {
 
   var self = this;
   return new Promise(function(resolve, reject) {
+    var onError = function(err) { reject(err); };
+    self.once(Link.ErrorReceived, onError);
     self.once(Link.CreditChange, function() {
+      self.removeListener(Link.ErrorReceived, onError);
       resolve();
-    });
-
-    self.once(Link.ErrorReceived, function(error) {
-      reject(error);
     });
   });
 };

--- a/lib/link.js
+++ b/lib/link.js
@@ -100,14 +100,13 @@ Link.prototype.attach = function() {
 Link.prototype.detach = function() {
   var self = this;
   var detachPromise = new Promise(function(resolve, reject) {
+    var onError = function(err) { reject(err); };
+    self.once(Link.ErrorReceived, onError);
     self.once(Link.Detached, function(info) {
+      self.removeListener(Link.ErrorReceived, onError);
       if (!!info.error) return reject(info.error);
       if (!info.closed) return reject('link not closed');
       resolve();
-    });
-
-    self.once(Link.ErrorReceived, function(err) {
-      reject(err);
     });
   });
 

--- a/lib/link.js
+++ b/lib/link.js
@@ -64,14 +64,18 @@ function Link(session, handle, linkPolicy) {
 util.inherits(Link, EventEmitter);
 
 // On receipt of a message.  Message payload given as argument.
-Link.MessageReceived = 'rxMessage';
-// Since 'error' events are "special" in Node (as in halt-the-process special), using a custom event for errors
-// we receive from the other endpoint.  Provides received AMQPError as an argument.
-Link.ErrorReceived = 'rxError';
+Link.MessageReceived = 'link:messageReceived';
+
+// Since 'error' events are "special" in Node (as in halt-the-process special),
+// using a custom event for errors we receive from the other endpoint. Provides
+// received AMQPError as an argument.
+Link.ErrorReceived = 'link:errorReceived';
+
 // On link credit changed.
-Link.CreditChange = 'linkCredit';
+Link.CreditChange = 'link:creditChange';
+
 // On completion of detach.
-Link.Detached = 'detached';
+Link.Detached = 'link:detached';
 
 // public api
 Link.prototype.attach = function() {

--- a/lib/session.js
+++ b/lib/session.js
@@ -164,17 +164,23 @@ function Session(conn) {
 util.inherits(Session, EventEmitter);
 
 // Events
-Session.Mapped = 'mapped';
-Session.Unmapped = 'unmapped';
-// Since 'error' events are "special" in Node (as in halt-the-process special), using a custom event for errors
-// we receive from the other endpoint.  Provides received AMQPError as an argument.
-Session.ErrorReceived = 'rxError';
+Session.Mapped = 'session:mapped';
+Session.Unmapped = 'session:unmapped';
+
+// Since 'error' events are "special" in Node (as in halt-the-process special),
+// using a custom event for errors we receive from the other endpoint. Provides
+// received AMQPError as an argument.
+Session.ErrorReceived = 'session:errorReceived';
+
 // On successful attach, Link given as argument.
-Session.LinkAttached = 'attached';
+Session.LinkAttached = 'session:linkAttached';
+
 // On completion of detach, Link given as argument.
-Session.LinkDetached = 'detached';
-// On receipt of a disposition frame, called with the first and last delivery-ids involved, whether they were settled, and the state.
-Session.DispositionReceived = 'disposition';
+Session.LinkDetached = 'session:linkDetached';
+
+// On receipt of a disposition frame, called with the first and last
+// delivery-ids involved, whether they were settled, and the state.
+Session.DispositionReceived = 'session:dispositionReceived';
 
 Session.prototype.begin = function(sessionPolicy) {
   var sessionParams = u.deepMerge(sessionPolicy.options);

--- a/lib/session.js
+++ b/lib/session.js
@@ -262,7 +262,7 @@ Session.prototype.addWindow = function(windowSize, flowOptions) {
 };
 
 Session.prototype.detachLink = function(link) {
-  link.detach();
+  return link.detach();
 };
 
 Session.prototype.end = function() {


### PR DESCRIPTION
* cleanup and standardize event names
* fix two EventEmitter leaks in link.js related to promisification 
