### PR TITLE
send disposition frames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,12 @@ before_script:
   - npm install -g codeclimate-test-reporter
   - sudo add-apt-repository ppa:mcpierce/qpid-testing -y
   - sudo apt-get update -q
-  - sudo apt-get install qpidd
+  - sudo apt-get install qpidd qpid-tools
   - sudo sh -c 'echo "auth=no" >> /etc/qpid/qpidd.conf'
   - sudo /etc/init.d/qpidd restart
+
+  # remove these when we can specify link properties
+  - sudo qpid-config add queue test.disposition.queue
 
 script:
   - make coverage

--- a/lib/frames/disposition_frame.js
+++ b/lib/frames/disposition_frame.js
@@ -13,8 +13,7 @@ var debug = require('debug')('amqp10:framing:disposition'),
     ForcedType = require('../types/forced_type'),
     AMQPSymbol = require('../types/amqp_symbol'),
 
-    FrameBase = require('./frame'),
-    BeginFrame = require('./begin_frame');
+    FrameBase = require('./frame');
 
 
 
@@ -115,7 +114,7 @@ DispositionFrame.Descriptor = {
 
 DispositionFrame.prototype._getPerformative = function() {
   var self = this;
-  return new DescribedType(BeginFrame.Descriptor.code, {
+  return new DescribedType(DispositionFrame.Descriptor.code, {
     role: self.role,
     first: new ForcedType('uint', self.first),
     last: new ForcedType('uint', self.last),

--- a/lib/frames/disposition_frame.js
+++ b/lib/frames/disposition_frame.js
@@ -89,8 +89,7 @@ var debug = require('debug')('amqp10:framing:disposition'),
  * @constructor
  */
 function DispositionFrame(options) {
-  DispositionFrame.super_.call(this);
-  this.channel = 0;
+  DispositionFrame.super_.call(this, options.channel);
   if (options instanceof DescribedType) {
     this.readPerformative(options);
     return;

--- a/lib/link.js
+++ b/lib/link.js
@@ -11,6 +11,7 @@ var _ = require('lodash'),
 
     constants = require('./constants'),
     errors = require('./errors'),
+    u = require('./utilities'),
 
     AttachFrame = require('./frames/attach_frame'),
     DetachFrame = require('./frames/detach_frame'),
@@ -18,7 +19,7 @@ var _ = require('lodash'),
     TransferFrame = require('./frames/transfer_frame'),
     DispositionFrame = require('./frames/disposition_frame'),
 
-    DeliveryStates = require('./types/delivery_states'),
+    DeliveryState = require('./types/delivery_state'),
     Session = require('./session');
 
 function Link(session, handle, linkPolicy) {
@@ -164,23 +165,19 @@ Link.prototype.addCredits = function(credits, flowOptions) {
 };
 
 Link.prototype.accept = function(message) {
-  // @todo: handle accepting an array of messages
-  this._sendDisposition({
-    first: message._deliveryId,
-    last: message._deliveryId,
+  var range = u.dispositionRange(message);
+  this._sendDisposition(_.defaults(range, {
     settled: true,
-    state: new DeliveryStates.Accepted()
-  });
+    state: new DeliveryState.Accepted()
+  }));
 };
 
 Link.prototype.reject = function(message, reason) {
-  // @todo: handle accepting an array of messages
-  this._sendDisposition({
-    first: message._deliveryId,
-    last: message._deliveryId,
+  var range = u.dispositionRange(message);
+  this._sendDisposition(_.defaults(range, {
     settled: true,
-    state: new DeliveryStates.Rejected({ error: reason })
-  });
+    state: new DeliveryState.Rejected({ error: reason })
+  }));
 };
 
 // private api
@@ -228,6 +225,14 @@ Link.prototype._messageReceived = function(transferFrame) {
   this.linkCredit--;
   debug('Rx message ' + transferFrame.deliveryId + ' on ' + this.name + ', ' + this.linkCredit + ' credit, ' + this.session._sessionParams.incomingWindow + ' window left.');
   // @todo Bump link credit based on strategy
+
+  // store deliveryId for later use
+  transferFrame.message._deliveryId = transferFrame.deliveryId;
+
+  // respect settle mode in policy
+  if (this.policy.options.receiverSettleMode === constants.receiverSettleMode.autoSettle)
+    this.accept(transferFrame.message);
+
   this.emit(Link.MessageReceived, transferFrame.message);
   this._checkCredit();
 };
@@ -236,6 +241,7 @@ Link.prototype._sendMessage = function(messageId, message, transferOptions) {
   if (this.linkCredit <= 0) {
     throw new errors.OverCapacityError('Cannot send if no link credit.');
   }
+
   var opts = transferOptions || {};
   opts.handle = this.handle;
   opts.deliveryId = messageId;

--- a/lib/link.js
+++ b/lib/link.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter,
+var _ = require('lodash'),
+    EventEmitter = require('events').EventEmitter,
     Promise = require('bluebird'),
     util = require('util'),
 
@@ -15,7 +16,9 @@ var EventEmitter = require('events').EventEmitter,
     DetachFrame = require('./frames/detach_frame'),
     FlowFrame = require('./frames/flow_frame'),
     TransferFrame = require('./frames/transfer_frame'),
+    DispositionFrame = require('./frames/disposition_frame'),
 
+    DeliveryStates = require('./types/delivery_states'),
     Session = require('./session');
 
 function Link(session, handle, linkPolicy) {
@@ -127,6 +130,58 @@ Link.prototype.sendMessage = function(message, options) {
   return this.session.sendMessage(this, message, options);
 };
 
+Link.prototype.addCredits = function(credits, flowOptions) {
+  if (this.role === constants.linkRole.sender) {
+    throw new errors.InvalidStateError('Cannot add link credits as a sender');
+  }
+
+  var opts = flowOptions || {};
+  this.linkCredit += credits;
+  this.totalCredits += credits;
+  opts.linkCredit = this.totalCredits;
+  this.session._sessionParams.incomingWindow += credits;
+  opts.nextIncomingId = this.session._sessionParams.nextIncomingId;
+  opts.incomingWindow = this.session._sessionParams.incomingWindow;
+  opts.nextOutgoingId = this.session._sessionParams.nextOutgoingId;
+  opts.outgoingWindow = this.session._sessionParams.outgoingWindow;
+  opts.handle = this.handle;
+  opts.available = this.available;
+  opts.deliveryCount = this.deliveryCount;
+  opts.drain = false;
+  var flow = new FlowFrame(opts);
+  flow.channel = this.session.channel;
+  this.session.connection.sendFrame(flow);
+
+  var self = this;
+  return new Promise(function(resolve, reject) {
+    var onError = function(err) { reject(err); };
+    self.once(Link.ErrorReceived, onError);
+    self.once(Link.CreditChange, function() {
+      self.removeListener(Link.ErrorReceived, onError);
+      resolve();
+    });
+  });
+};
+
+Link.prototype.accept = function(message) {
+  // @todo: handle accepting an array of messages
+  this._sendDisposition({
+    first: message._deliveryId,
+    last: message._deliveryId,
+    settled: true,
+    state: new DeliveryStates.Accepted()
+  });
+};
+
+Link.prototype.reject = function(message, reason) {
+  // @todo: handle accepting an array of messages
+  this._sendDisposition({
+    first: message._deliveryId,
+    last: message._deliveryId,
+    settled: true,
+    state: new DeliveryStates.Rejected({ error: reason })
+  });
+};
 
 // private api
 Link.prototype._attachReceived = function(attachFrame) {
@@ -159,39 +214,6 @@ Link.prototype._flowReceived = function(flowFrame) {
   } else {
     this.drain = flowFrame.drain;
   }
-};
-
-Link.prototype.addCredits = function(credits, flowOptions) {
-  if (this.role === constants.linkRole.sender) {
-    throw new errors.InvalidStateError('Cannot add link credits as a sender');
-  }
-
-  var opts = flowOptions || {};
-  this.linkCredit += credits;
-  this.totalCredits += credits;
-  opts.linkCredit = this.totalCredits;
-  this.session._sessionParams.incomingWindow += credits;
-  opts.nextIncomingId = this.session._sessionParams.nextIncomingId;
-  opts.incomingWindow = this.session._sessionParams.incomingWindow;
-  opts.nextOutgoingId = this.session._sessionParams.nextOutgoingId;
-  opts.outgoingWindow = this.session._sessionParams.outgoingWindow;
-  opts.handle = this.handle;
-  opts.available = this.available;
-  opts.deliveryCount = this.deliveryCount;
-  opts.drain = false;
-  var flow = new FlowFrame(opts);
-  flow.channel = this.session.channel;
-  this.session.connection.sendFrame(flow);
-
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    var onError = function(err) { reject(err); };
-    self.once(Link.ErrorReceived, onError);
-    self.once(Link.CreditChange, function() {
-      self.removeListener(Link.ErrorReceived, onError);
-      resolve();
-    });
-  });
 };
 
 Link.prototype._checkCredit = function() {
@@ -256,6 +278,18 @@ Link.prototype._detached = function(frame) {
 
   // @todo: Session should listen for Link.Detached
   this.session._linkDetached(this);
+};
+
+Link.prototype._sendDisposition = function(options) {
+  var dispositionOptions = _.defaults(options, {
+    role: constants.linkRole.receiver,
+    channel: this.session.channel,
+    handle: this.handle
+  });
+
+  this.session.connection.sendFrame(
+    new DispositionFrame(dispositionOptions)
+  );
 };
 
 module.exports = Link;

--- a/lib/types/delivery_state.js
+++ b/lib/types/delivery_state.js
@@ -10,16 +10,25 @@ var Int64 = require('node-int64'),
     AMQPError = require('./amqp_error'),
     DescribedType = require('./described_type'),
     ForcedType = require('./forced_type'),
-    AMQPSymbol = require('./amqp_symbol');
+    AMQPSymbol = require('./amqp_symbol'),
+    AMQPFields = require('./amqp_composites').Fields;
 
+/**
+ * Delivery state base class
+ */
 function DeliveryState(code) {
   DeliveryState.super_.call(this, code);
 }
 
 util.inherits(DeliveryState, DescribedType);
 
-module.exports.DeliveryState = DeliveryState;
-
+/**
+ * Received
+ * The received outcome
+ *
+ * @param sectionNumber
+ * @param sectionOffset
+ */
 function Received(options) {
   Received.super_.call(this, Received.Descriptor.code);
   u.assertArguments(options, ['sectionNumber', 'sectionOffset']);
@@ -49,8 +58,10 @@ Received.Descriptor = {
   code: new Int64(0x0, 0x23)
 };
 
-module.exports.Received = Received;
-
+/**
+ * Accepted
+ * The accepted state
+ */
 function Accepted(options) {
   Accepted.super_.call(this, Accepted.Descriptor.code);
 }
@@ -70,8 +81,12 @@ Accepted.Descriptor = {
   code: new Int64(0x0, 0x24)
 };
 
-module.exports.Accepted = Accepted;
-
+/**
+ * Reject
+ * The rejected state
+ *
+ * @param error
+ */
 function Rejected(options) {
   Rejected.super_.call(this, Rejected.Descriptor.code);
 
@@ -79,7 +94,7 @@ function Rejected(options) {
   if (options instanceof AMQPError) {
     this.error = options;
   } else {
-    // TODO: qpid sends back no error, what should this message be?
+    // @todo: qpid sends back no error, what should this message be?
     this.error = options.error || "rejected";
   }
 }
@@ -99,8 +114,10 @@ Rejected.Descriptor = {
   code: new Int64(0x0, 0x25)
 };
 
-module.exports.Rejected = Rejected;
-
+/**
+ * Released
+ * The released outcome.
+ */
 function Released(options) {
   Released.super_.call(this, Released.Descriptor.code);
 }
@@ -120,4 +137,53 @@ Released.Descriptor = {
   code: new Int64(0x0, 0x26)
 };
 
-module.exports.Released = Released;
+/**
+ * Modified
+ * The modified outcome
+ *
+ * @param deliveryFailed
+ * @param undeliverableHere
+ * @param messageAnnotations
+ */
+function Modified(options) {
+  Modified.super_.call(this, Modified.Descriptor.code);
+  u.assertArguments(options, ['deliveryFailed', 'undeliverableHere', 'messageAnnotations']);
+  this.deliveryFailed = options.deliveryFailed;
+  this.undeliverableHere = options.undeliverableHere;
+  this.messageAnnotations = options.messageAnnotations;
+}
+
+util.inherits(Modified, DeliveryState);
+
+Modified.fromDescribedType = function(describedType) {
+  var options = {
+    deliveryFailed: describedType.value[0],
+    undeliverableHere: describedType.value[1],
+    messageAnnotations: describedType.value[2]
+  };
+
+  return new Modified(options);
+};
+
+Modified.prototype.getValue = function() {
+  var self = this;
+  return [
+    new ForcedType('bool', self.deliveryFailed),
+    new ForcedType('bool', self.undeliverableHere),
+    new AMQPFields(self.messageAnnotations)
+  ];
+};
+
+Modified.Descriptor = {
+  name: new AMQPSymbol('amqp:modified:list'),
+  code: new Int64(0x0, 0x27)
+};
+
+module.exports = {
+  DeliveryState: DeliveryState,
+  Received: Received,
+  Accepted: Accepted,
+  Rejected: Rejected,
+  Released: Released,
+  Modified: Modified
+};

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var debug = require('debug')('amqp10:utilities'),
+var _ = require('lodash'),
+    debug = require('debug')('amqp10:utilities'),
 
     constants = require('./constants'),
     errors = require('./errors');
@@ -247,4 +248,25 @@ module.exports.generateTimeouts = function(options) {
       return result;
     }, [])
     .map(function(i) { return i * 1000; });
+};
+
+/**
+ * Calculates the start and end for a disposition frame
+ *
+ * @param message either a single message or an array of them
+ * @return {Object}
+ */
+module.exports.dispositionRange = function(message) {
+  var first, last;
+  if (_.isArray(message)) {
+    first = message[0]._deliveryId;
+    last = message[message.length - 1]._deliveryId;
+  } else {
+    first = last = message._deliveryId;
+  }
+
+  return {
+    first: first,
+    last: last
+  };
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "istanbul": "^0.3.6",
     "jshint": "^2.6.0",
     "mocha": "^2.1.0",
-    "stream-buffers": "2.1.0"
+    "stream-buffers": "2.1.0",
+    "qmf2": "^0.0.1"
   },
   "scripts": {},
   "author": {

--- a/test/integration/qpid/disposition.test.js
+++ b/test/integration/qpid/disposition.test.js
@@ -1,0 +1,53 @@
+'use strict';
+var AMQPClient = require('../../..').Client,
+    Message = require('../../../lib/types/message'),
+    Promise = require('bluebird'),
+    config = require('./config'),
+    expect = require('chai').expect,
+    BrokerAgent = require('qmf2');
+
+var test = {};
+describe('QPID', function() {
+
+describe('Disposition', function() {
+  beforeEach(function() {
+    if (!!test.client) test.client = undefined;
+    test.client = new AMQPClient();
+  });
+
+  afterEach(function() {
+    return test.client.disconnect().then(function() {
+      test.client = undefined;
+      test.broker = undefined;
+    });
+  });
+
+  it('should auto-settle messages received from queue', function(done) {
+    var queueName = 'test.disposition.queue';
+    var messageCount = 0;
+    return test.client.connect(config.address)
+      .then(function() {
+        test.broker = new BrokerAgent(test.client);
+        return test.client.createReceiver(queueName, null, function(err, message) {
+          expect(err).to.not.exist;
+          messageCount++;
+          if (messageCount !== 2)
+            return;
+
+          test.broker.getQueue(queueName)
+            .then(function(queue) {
+              expect(queue.msgDepth.toNumber(true)).to.equal(0);
+              done();
+            });
+        });
+      })
+      .then(function() {
+        return Promise.all([
+          test.client.send('first message', queueName),
+          test.client.send('second message', queueName)
+        ]);
+      });
+  });
+
+});
+});


### PR DESCRIPTION
* provide two new methods Link.accept and Link.reject to handle manual disposition
* use Link.accept to enable our auto-settle behavior, by sending disposition frames upon dequeueing messages
* add an integration test proving this all works
* fixed an issue with DispositionFrame not using the proper channel number