### PR TITLE
refactor(SenderLink): unify sendMessage implementations

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -298,7 +298,10 @@ AMQPClient.prototype.send = function(msg, target, options) {
           reject(err);
         } else {
           debug('sending: ', msg);
-          var msgId = _link.sendMessage(message, {deliveryTag: new Buffer(curId.toString())});
+          var msgId = _link._sendMessage(message, {
+            deliveryTag: new Buffer(curId.toString())
+          });
+
           var cbPolicy = self.policy.senderLink.callback;
           if (cbPolicy === putils.SenderCallbackPolicies.OnSettle) {
             self._unsettledSends[msgId] = deferredSender;

--- a/lib/sender_link.js
+++ b/lib/sender_link.js
@@ -33,18 +33,37 @@ SenderLink.prototype.canSend = function() {
   return sendable;
 };
 
-SenderLink.prototype.sendMessage = function(message, options) {
-  return this.session.sendMessage(this, message, options);
-};
-
 // private API
-SenderLink.prototype._sendMessage = function(messageId, message, transferOptions) {
+SenderLink.prototype._sendMessage = function(message, options) {
+  // preconditions
   if (this.linkCredit <= 0) {
     throw new errors.OverCapacityError('Cannot send if no link credit.');
   }
 
-  transferOptions = transferOptions || {};
-  var options = _.defaults(transferOptions, {
+  options = options || {};
+
+  // session bookkeeping
+  var messageId = this.session._sessionParams.nextOutgoingId;
+  this.session._sessionParams.nextOutgoingId++;
+  this.session._sessionParams.remoteIncomingWindow--;
+  this.session._sessionParams.outgoingWindow--;
+  if (this.session._sessionParams.remoteIncomingWindow < 0) {
+    if (this.session.policy.enableSessionFlowControl) {
+      throw new errors.OverCapacityError('Cannot send message - over Session window capacity (' + this.session._sessionParams.remoteIncomingWindow + ' window)');
+    } else {
+      this.session._sessionParams.remoteIncomingWindow =
+        this.session._sessionParams.outgoingWindow = 0;
+    }
+  }
+
+  this.session._transfersInFlight[messageId] = {
+    message: message,
+    options: options,
+    sent: Date.now()
+  };
+
+  // create frame and send
+  var transferOptions = _.defaults(options, {
     channel: this.session.channel,
     handle: this.handle,
     deliveryId: messageId,
@@ -53,7 +72,7 @@ SenderLink.prototype._sendMessage = function(messageId, message, transferOptions
   });
 
   this.linkCredit--;
-  this.session.connection.sendFrame(new TransferFrame(options));
+  this.session.connection.sendFrame(new TransferFrame(transferOptions));
   return messageId;
 };
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -231,29 +231,6 @@ Session.prototype._linkDetached = function(link) {
   this.emit(Session.LinkDetached, link);
 };
 
-/**
- *
- * @param {Link} link
- * @param {Message} message
- * @param {*} options
- */
-Session.prototype.sendMessage = function(link, message, options) {
-  var messageId = this._sessionParams.nextOutgoingId;
-  this._sessionParams.nextOutgoingId++;
-  this._sessionParams.remoteIncomingWindow--;
-  this._sessionParams.outgoingWindow--;
-  if (this._sessionParams.remoteIncomingWindow < 0) {
-    if (this.policy.enableSessionFlowControl) {
-      throw new errors.OverCapacityError('Cannot send message - over Session window capacity (' + this._sessionParams.remoteIncomingWindow + ' window)');
-    } else {
-      this._sessionParams.remoteIncomingWindow = this._sessionParams.outgoingWindow = 0;
-    }
-  }
-
-  this._transfersInFlight[messageId] = { message: message, options: options, sent: Date.now() };
-  return link._sendMessage(messageId, message, options);
-};
-
 Session.prototype.addWindow = function(windowSize, flowOptions) {
   var opts = flowOptions || {};
   this._sessionParams.incomingWindow += windowSize;

--- a/test/unit/test_amqpclient.js
+++ b/test/unit/test_amqpclient.js
@@ -72,7 +72,7 @@ MockLink.prototype.canSend = function() {
   return this.capacity > 0;
 };
 
-MockLink.prototype.sendMessage = function(msg, options) {
+MockLink.prototype._sendMessage = function(msg, options) {
   this.curId++;
   this.messages.push({ id: this.curId, message: msg.body[0], options: options });
   this.emit('sendMessage-called', this, this.curId, msg, options);


### PR DESCRIPTION
Moved sendMessage out of Session into SenderLink. At the same time
unified the two sendMessage's in SenderLink into just the private
version, in anticipation of moving AMQPClient.send into SenderLink