### PR TITLE
feat(createReceiver): allow user to specify receiver link policy

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -478,14 +478,15 @@ AMQPClient.prototype.send = function(msg, target, options) {
  *
  * @method createReceiver
  * @param {string} [source]     Source of the link to connect to.  If not provided will use default queue from connection uri.
- * @param {*} [filter]          Filter used in connecting to the source.  See AMQP spec for details, and your server's documentation
+ * @param {Object} [options]    Options used for link creation
+ * @param options.filter        Filter used in connecting to the source.  See AMQP spec for details, and your server's documentation
  *                              for possible values.  node-amqp-encoder'd maps will be translated, and simple maps will be converted
  *                              to AMQP Fields type as defined in the spec.
  * @param {function} cb         Callback to invoke on every receipt.  Called with (error, message).
  *
  * @return {Promise}
  */
-AMQPClient.prototype.createReceiver = function(address, filter, cb) {
+AMQPClient.prototype.createReceiver = function(address, options, cb) {
   if (!this._connection) { throw new Error('Must connect before receiving'); }
 
   var self = this;
@@ -493,20 +494,15 @@ AMQPClient.prototype.createReceiver = function(address, filter, cb) {
     if (typeof address === 'function') {
       cb = address;
       address = this._defaultQueue;
-      filter = undefined;
+      options = undefined;
     } else if (typeof address !== 'string') {
-      cb = filter;
-      filter = address;
+      cb = options;
+      options = address;
       address = this._defaultQueue;
     } else {
-      cb = filter;
-      filter = undefined;
+      cb = options;
+      options = undefined;
     }
-  }
-
-  if (filter && filter instanceof Array && filter[0] === 'map') {
-    // Convert encoded values
-    filter = AMQPClient.adapters.Translator(filter);
   }
 
   var linkName = address + '_RX';
@@ -523,6 +519,22 @@ AMQPClient.prototype.createReceiver = function(address, filter, cb) {
 
       self.on(AMQPClient.LinkAttached, attachingListener);
     });
+  }
+
+  var linkPolicy = u.deepMerge({
+    options: {
+      name: linkName,
+      source: { address: address },
+      target: { address: 'localhost' }
+    }
+  }, self.policy.receiverLink);
+
+  if (options) {
+    if (options.filter && options.filter instanceof Array && options[0] === 'map') {
+      // Convert encoded values
+      options.filter = AMQPClient.adapters.Translator(options.filter);
+      linkPolicy.source.filter = options.filter;
+    }
   }
 
   return new Promise(function(resolve, reject) {
@@ -589,13 +601,6 @@ AMQPClient.prototype.createReceiver = function(address, filter, cb) {
 
       var onMapped = function() {
         self.removeListener(AMQPClient.SessionMapped, onMapped);
-        var linkPolicy = u.deepMerge({
-          options: {
-            name: linkName,
-            source: {address: address, filter: filter},
-            target: {address: 'localhost'}
-          }
-        }, self.policy.receiverLink);
         self._session.attachLink(linkPolicy);
       };
 

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -485,19 +485,19 @@ AMQPClient.prototype.send = function(msg, target, options) {
  *
  * @return {Promise}
  */
-AMQPClient.prototype.createReceiver = function(source, filter, cb) {
+AMQPClient.prototype.createReceiver = function(address, filter, cb) {
   if (!this._connection) { throw new Error('Must connect before receiving'); }
 
   var self = this;
   if (cb === undefined) {
-    if (typeof source === 'function') {
-      cb = source;
-      source = this._defaultQueue;
+    if (typeof address === 'function') {
+      cb = address;
+      address = this._defaultQueue;
       filter = undefined;
-    } else if (typeof source !== 'string') {
+    } else if (typeof address !== 'string') {
       cb = filter;
-      filter = source;
-      source = this._defaultQueue;
+      filter = address;
+      address = this._defaultQueue;
     } else {
       cb = filter;
       filter = undefined;
@@ -509,7 +509,7 @@ AMQPClient.prototype.createReceiver = function(source, filter, cb) {
     filter = AMQPClient.adapters.Translator(filter);
   }
 
-  var linkName = source + '_RX';
+  var linkName = address + '_RX';
   if (this._attaching[linkName]) {
     self._onReceipt[linkName].push(cb);
 
@@ -564,7 +564,7 @@ AMQPClient.prototype.createReceiver = function(source, filter, cb) {
           l.on(Link.MessageReceived, function(message) {
             var payload = message.body[0] || message.body;
             message.body = l.policy.decoder ? l.policy.decoder(payload) : payload;
-            debug('received from (' + source + '): ' + message.body);
+            debug('received from (' + address + '): ' + message.body);
             var cbs = self._onReceipt[linkName];
             if (cbs && cbs.length > 0) {
               cbs.forEach(function (cb) {
@@ -587,27 +587,21 @@ AMQPClient.prototype.createReceiver = function(source, filter, cb) {
 
       self.on(AMQPClient.LinkAttached, onAttached);
 
-      if (self._session) {
+      var onMapped = function() {
+        self.removeListener(AMQPClient.SessionMapped, onMapped);
         var linkPolicy = u.deepMerge({
           options: {
             name: linkName,
-            source: {address: source, filter: filter},
+            source: {address: address, filter: filter},
             target: {address: 'localhost'}
           }
         }, self.policy.receiverLink);
         self._session.attachLink(linkPolicy);
+      };
+
+      if (self._session) {
+        onMapped();
       } else {
-        var onMapped = function() {
-          self.removeListener(AMQPClient.SessionMapped, onMapped);
-          var linkPolicy = u.deepMerge({
-            options: {
-              name: linkName,
-              source: {address: source, filter: filter},
-              target: {address: 'localhost'}
-            }
-          }, self.policy.receiverLink);
-          self._session.attachLink(linkPolicy);
-        };
         self.on(AMQPClient.SessionMapped, onMapped);
       }
     };

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -500,8 +500,10 @@ AMQPClient.prototype.createReceiver = function(address, options, cb) {
       options = address;
       address = this._defaultQueue;
     } else {
-      cb = options;
-      options = undefined;
+      if (typeof options !== 'object') {
+        cb = options;
+        options = undefined;
+      }
     }
   }
 
@@ -534,6 +536,10 @@ AMQPClient.prototype.createReceiver = function(address, options, cb) {
       // Convert encoded values
       options.filter = AMQPClient.adapters.Translator(options.filter);
       linkPolicy.source.filter = options.filter;
+    }
+
+    if (options.policy) {
+      u.deepMerge(linkPolicy, options.policy);
     }
   }
 

--- a/test/integration/qpid/disposition.test.js
+++ b/test/integration/qpid/disposition.test.js
@@ -58,17 +58,16 @@ describe('Disposition', function() {
     var queueName = 'test.disposition.queue';
     var messageCount = 0;
 
-    test.client.policy.receiverLink.options.receiverSettleMode =
-      c.receiverSettleMode.settleOnDisposition;
-    test.client.policy.receiverLink.credit = function(link) {
-      if (link.name === 'qmf.default.topic_RX') link.addCredits(1);
-    };
-
     return test.client.connect(config.address)
       .then(function() {
         test.broker = new BrokerAgent(test.client);
         return Promise.all([
-          test.client.createReceiver(queueName),
+          test.client.createReceiver(queueName, {
+            policy: {
+              receiverSettleMode: c.receiverSettleMode.settleOnDisposition,
+              credit: function(link) {}
+            }
+          }),
           test.client.createSender(queueName)
         ]);
       })

--- a/test/unit/test_amqpclient.js
+++ b/test/unit/test_amqpclient.js
@@ -653,7 +653,7 @@ describe('AMQPClient', function() {
 
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
-        expect(_policy.options.source).to.eql({ address: queue, filter: undefined });
+        expect(_policy.options.source).to.eql({ address: queue });
         expect(_policy.options.role).to.eql(constants.linkRole.receiver);
         _s.emit(Session.LinkAttached, _l);
       });
@@ -712,7 +712,7 @@ describe('AMQPClient', function() {
 
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
-        expect(_policy.options.source).to.eql({ address: queue, filter: undefined });
+        expect(_policy.options.source).to.eql({ address: queue });
         expect(_policy.options.role).to.eql(constants.linkRole.receiver);
         _s.emit(Session.LinkAttached, _l);
       });
@@ -816,7 +816,7 @@ describe('AMQPClient', function() {
 
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
-        expect(_policy.options.source).to.eql({ address: queue, filter: undefined });
+        expect(_policy.options.source).to.eql({ address: queue });
         expect(_policy.options.role).to.eql(constants.linkRole.receiver);
         if (called.attachLink === 1) {
           process.nextTick(function() {
@@ -871,7 +871,7 @@ describe('AMQPClient', function() {
 
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
-        expect(_policy.options.source).to.eql({ address: queue, filter: undefined });
+        expect(_policy.options.source).to.eql({ address: queue });
         expect(_policy.options.role).to.eql(constants.linkRole.receiver);
         if (called.attachLink === 1) {
           process.nextTick(function() {


### PR DESCRIPTION
This allows the user to specify a custom receiver link policy when using AMQPClient.createReceiver. A number of other cleanups are included in this PR, but should be relatively easy to follow (they are incremental, commits should be self-explanatory)