### PR TITLE
refactor(timestamps): use Date as the primary expression of ms64

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -238,6 +238,8 @@ Codec.prototype.encode = function(val, buf, forceType) {
       } else if (val instanceof Array) {
         encoder = types.builders.list;
         return encoder(val, buf, this);
+      } else if (val instanceof Date) {
+        return types.builders.timestamp(new Int64(val.getTime()), buf, this);
       } else if (val instanceof ForcedType) {
         return this.encode(val.value, buf, val.typeName);
       } else if (val instanceof DescribedType) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -607,7 +607,16 @@ Types.prototype._initTypesArray = function() {
               throw new errors.EncodingError('Invalid encoding type for 64-bit value: ' + val);
             }
           },
-          decoder: function(buf) { return new Int64(buf); }
+          decoder: function(buf) {
+            var tmp = new Int64(buf);
+            return new Date(tmp.toNumber(false));
+
+            // @todo: the above conversion is potentially imprecise. We used to
+            //        simply run the following line, giving a user access to the
+            //        exact value. In the future we should allow users to opt-out
+            //        of the above convenience.
+            // return new Int64(buf);
+          }
         }
       ]
     },

--- a/test/integration/qpid/types.test.js
+++ b/test/integration/qpid/types.test.js
@@ -39,5 +39,25 @@ describe('Types', function() {
       });
   });
 
+  it('should be able to send timestamps', function(done) {
+    var timestamp = { test: new Date() };
+
+    test.client.connect(config.address)
+      .then(function() {
+        return Promise.all([
+          test.client.createReceiver(config.defaultLink),
+          test.client.createSender(config.defaultLink)
+        ]);
+      })
+      .spread(function(receiver, sender) {
+        receiver.on('message', function(message) {
+          expect(message.body).to.eql(timestamp);
+          done();
+        });
+
+        return sender.send(timestamp);
+      });
+  });
+
 });
 });

--- a/test/unit/test_types.js
+++ b/test/unit/test_types.js
@@ -528,10 +528,17 @@ describe('Types', function() {
             ]),
             expectedOutput: '797ff043-11eb-11e1-80d6-510998755d10'
           },
+
+          // @todo: reenable this when we figure out how to mix Int64 with Dates
+          // {
+          //   name: 'ms64 (timestamp)',
+          //   value: buf([0x83, 0x00, 0x00, 0x00, 0x00, 0x55, 0x10, 0x7B, 0x38]),
+          //   expectedOutput: new Int64(1427143480)
+          // },
           {
             name: 'ms64 (timestamp)',
             value: buf([0x83, 0x00, 0x00, 0x00, 0x00, 0x55, 0x10, 0x7B, 0x38]),
-            expectedOutput: new Int64(1427143480)
+            expectedOutput: new Date(1427143480)
           },
           { name: 'vbin8', value: buf([0xa0, 0x01, 0x10]), expectedOutput: new Buffer([0x10]) },
           {


### PR DESCRIPTION
Timestamps in AMQP 1.0 are expressed as 64bit unsigned integers, of
course this doesn't jive with Javascript. As a convenience to our
users, this patch defaults to converting all timestamps (incoming
and outgoing) to Date objects. This can be imprecise, and we will
need to investigate future means of opting out of this conversion.