### PR TITLE
fix(disposition): only send disposition to relevant links by role

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -119,8 +119,10 @@ function Session(conn) {
   this._allocatedHandles = {};
   this._linksByName = {};
   this._linksByRemoteHandle = {};
-  this._senderLinks = [];
   this._deliveryTag = 1;
+
+  this._senderLinks = [];
+  this._receiverLinks = [];
 
   var self = this;
   var stateMachine = {
@@ -216,6 +218,7 @@ Session.prototype.attachLink = function(linkPolicy) {
     this._senderLinks.push(link);
   } else {
     link = new ReceiverLink(this, policy.options.handle, policy);
+    this._receiverLinks.push(link);
   }
 
   this._allocatedHandles[policy.options.handle] = link;
@@ -414,9 +417,12 @@ Session.prototype._handleDisposition = function(frame) {
     state: frame.state
   };
 
-  _.values(this._linksByName).forEach(function(link) {
-    link._dispositionReceived(disposition);
-  });
+  var dispositionHandler = function(l) { l._dispositionReceived(disposition); };
+  if (frame.role === constants.linkRole.sender) {
+    this._receiverLinks.forEach(dispositionHandler);
+  } else {
+    this._senderLinks.forEach(dispositionHandler);
+  }
 
   this.emit(Session.DispositionReceived, disposition);
 };


### PR DESCRIPTION
Previously we ignored the role of the incoming disposition frame,
and forwarded these frames to the _dispositionRecieved method of
all links we knew about. This patch corrects this behavior, and
includes an integration test verifying that frames are forwarded
to the appropriate link types.