### PR TITLE
Link creation cleanup

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -205,6 +205,16 @@ AMQPClient.prototype._resolveDeferredSenderAttaches = function(linkName, err, li
   this._senderAttaching[linkName] = undefined;
 };
 
+AMQPClient.prototype._resolveDeferredReceiverAttaches = function(linkName, err, link) {
+  // resolve deferred attachments
+  while (this._attaching[linkName].length) {
+    var deferredAttach = this._attaching[linkName].shift();
+    deferredAttach(err, link);
+  }
+
+  this._attaching[linkName] = undefined;
+};
+
 /**
  * Creates a sender link for the given address, with optional link options
  *
@@ -225,18 +235,14 @@ AMQPClient.prototype.createSender = function(address, options) {
 
     // return cached link if it exists
     if (self._attached[linkName]) {
-      resolve(self._attached[linkName]);
-      return;
+      return resolve(self._attached[linkName]);
     }
 
     // return deferred attach promise if already attaching
     if (self._senderAttaching[linkName]) {
       var deferredAttach = function(err, link) {
-        if (!!err) {
-          return reject(err);
-        }
-
-        resolve(link);
+        if (!!err) return reject(err);
+        return resolve(link);
       };
 
       self._senderAttaching[linkName].push(deferredAttach);
@@ -289,7 +295,9 @@ AMQPClient.prototype.createSender = function(address, options) {
         }, self.policy.senderLink);
         self._session.attachLink(linkPolicy);
       };
-      (self._session) ? onMapped() : self.on(AMQPClient.SessionMapped, onMapped);
+
+      (self._session && self._session.mapped) ?
+        onMapped() : self.on(AMQPClient.SessionMapped, onMapped);
     };
 
     self._reattach[linkName] = attach;
@@ -321,20 +329,8 @@ AMQPClient.prototype.createReceiver = function(address, options) {
   options = options || {};
 
   var self = this;
+
   var linkName = address + '_RX';
-  if (this._attaching[linkName]) {
-    return new Promise(function(resolve, reject) {
-      var attachingListener = function(link) {
-        if (link.name === linkName) {
-          self.removeListener(AMQPClient.LinkAttached, attachingListener);
-          resolve(link);
-        }
-      };
-
-      self.on(AMQPClient.LinkAttached, attachingListener);
-    });
-  }
-
   var linkPolicy = u.deepMerge({
     options: {
       name: linkName,
@@ -356,39 +352,46 @@ AMQPClient.prototype.createReceiver = function(address, options) {
   }
 
   return new Promise(function(resolve, reject) {
-    if (self._attached[linkName])
+    // return cached link if it exists
+    if (self._attached[linkName]) {
       return resolve(self._attached[linkName]);
+    }
+
+    // return deferred attach promise if already attaching
+    if (self._attaching[linkName]) {
+      var deferredAttach = function(err, link) {
+        if (!!err) return reject(err);
+        return resolve(link);
+      };
+
+      self._attaching[linkName].push(deferredAttach);
+      return;
+    }
 
     // otherwise create the link, and set initial state
     if (self._attached[linkName] === undefined) self._attached[linkName] = null;
-    if (self._attaching[linkName] === undefined) self._attaching[linkName] = false;
+    if (self._attaching[linkName] === undefined) self._attaching[linkName] = [];
 
     var attach = function() {
-      self._attaching[linkName] = true;
-
-      var onAttached = function(l) {
-        if (l.name === linkName) {
-          debug('receiver link attached: ' + linkName);
-          self.removeListener(AMQPClient.LinkAttached, onAttached);
-          self._attaching[linkName] = false;
-          self._attached[linkName] = l;
-
-          l.on(Link.ErrorReceived, function(err) {
-            // @todo: most likely never called, research a way to properly
-            //        resolve or reject this promise.
-            reject(err);
-          });
-
-          l.on(Link.Detached, function(details) {
-            debug('link detached: ' + (details ? details.error : 'No details'));
-            self._attached[linkName] = undefined;
-
-            // @todo: investigate options/policies for auto-reattach
-            // attach();
-          });
-
-          resolve(l);
+      var onAttached = function(link) {
+        if (link.name !== linkName) {
+          return;
         }
+
+        debug('receiver link attached: ' + link.name);
+        self.removeListener(AMQPClient.LinkAttached, onAttached);
+        self._attached[linkName] = link;
+
+        link.on(Link.Detached, function(details) {
+          debug('link detached: ' + (details ? details.error : 'No details'));
+          self._attached[linkName] = undefined;
+
+          // @todo: investigate options/policies for auto-reattach
+          // attach();
+        });
+
+        self._resolveDeferredReceiverAttaches(linkName, null, link);
+        resolve(link);
       };
 
       self.on(AMQPClient.LinkAttached, onAttached);
@@ -398,18 +401,14 @@ AMQPClient.prototype.createReceiver = function(address, options) {
         self._session.attachLink(linkPolicy);
       };
 
-      if (self._session) {
-        onMapped();
-      } else {
-        self.on(AMQPClient.SessionMapped, onMapped);
-      }
+      (self._session && self._session.mapped) ?
+        onMapped() : self.on(AMQPClient.SessionMapped, onMapped);
     };
 
     self._reattach[linkName] = attach;
 
-    if (!self._attached[linkName]) {
-      attach();
-    }
+    // attempt to attach the link
+    attach();
   });
 };
 
@@ -441,6 +440,7 @@ AMQPClient.prototype.disconnect = function() {
 AMQPClient.prototype._clearConnectionState = function(saveReconnectDetails) {
   this._attached = {};
   this._attaching = {};
+  this._senderAttaching = {};
   this._connection = null;
   this._session = null;
   // Copy from original to avoid any settings changes "sticking" across connections.

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -229,6 +229,9 @@ AMQPClient.prototype.createSender = function(address, options) {
     throw new Error('Must connect before creating links');
   }
 
+  address = address || this._defaultQueue;
+  options = options || {};
+
   var linkName = address + '_TX';
   var linkPolicy = u.deepMerge({
     options: {
@@ -269,17 +272,11 @@ AMQPClient.prototype.createSender = function(address, options) {
 
         link.on(Link.ErrorReceived, function(err) {
           self.emit(AMQPClient.ErrorReceived, err);
-
-          self._resolveDeferredSenderAttaches(linkName, err);
-          reject(err);
         });
 
         link.on(Link.Detached, function(details) {
           debug('sender link detached: ' + (details ? details.error : 'No details'));
           self._attached[linkName] = undefined;
-
-          self._resolveDeferredSenderAttaches(linkName, details);
-          reject(details);
         });
 
         // return the attached link
@@ -321,7 +318,9 @@ AMQPClient.prototype.createSender = function(address, options) {
  * @return {Promise}
  */
 AMQPClient.prototype.createReceiver = function(address, options) {
-  if (!this._connection) { throw new Error('Must connect before receiving'); }
+  if (!this._connection) {
+    throw new Error('Must connect before creating links');
+  }
 
   address = address || this._defaultQueue;
   options = options || {};
@@ -374,6 +373,10 @@ AMQPClient.prototype.createReceiver = function(address, options) {
         debug('receiver link attached: ' + link.name);
         link.removeListener(Link.Attached, onAttached);
         self._attached[linkName] = link;
+
+        link.on(Link.ErrorReceived, function(err) {
+          self.emit(AMQPClient.ErrorReceived, err);
+        });
 
         link.on(Link.Detached, function(details) {
           debug('link detached: ' + (details ? details.error : 'No details'));

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -87,12 +87,12 @@ util.inherits(AMQPClient, EventEmitter);
 
 // Events - mostly for internal use.
 AMQPClient.ErrorReceived = 'client:errorReceived'; // Called with error
+
 AMQPClient.ConnectionOpened = 'connection:opened';
-AMQPClient.SessionMapped = 'session:mapped';
-AMQPClient.LinkAttached = 'link:attached'; // Called with link
-AMQPClient.LinkDetached = 'link:detached'; // Called with link
-AMQPClient.SessionUnmapped = 'session:unmapped';
 AMQPClient.ConnectionClosed = 'connection:closed';
+
+AMQPClient.SessionMapped = 'session:mapped';
+AMQPClient.SessionUnmapped = 'session:unmapped';
 
 
 /**
@@ -229,10 +229,18 @@ AMQPClient.prototype.createSender = function(address, options) {
     throw new Error('Must connect before creating links');
   }
 
+  var linkName = address + '_TX';
+  var linkPolicy = u.deepMerge({
+    options: {
+      name: linkName,
+      source: { address: 'localhost' },
+      target: { address: address }
+    }
+  }, this.policy.senderLink);
+
+
   var self = this;
   return new Promise(function(resolve, reject) {
-    var linkName = address + '_TX';
-
     // return cached link if it exists
     if (self._attached[linkName]) {
       return resolve(self._attached[linkName]);
@@ -255,12 +263,8 @@ AMQPClient.prototype.createSender = function(address, options) {
 
     var attach = function() {
       var onAttached = function(link) {
-        if (link.name !== linkName) {
-          return;
-        }
-
         debug('sender link attached: ' + linkName);
-        self.removeListener(AMQPClient.LinkAttached, onAttached);
+        link.removeListener(Link.Attached, onAttached);
         self._attached[linkName] = link;
 
         link.on(Link.ErrorReceived, function(err) {
@@ -282,18 +286,12 @@ AMQPClient.prototype.createSender = function(address, options) {
         self._resolveDeferredSenderAttaches(linkName, null, link);
         resolve(link);
       };
-      self.on(AMQPClient.LinkAttached, onAttached);
 
       var onMapped = function() {
         self.removeListener(AMQPClient.SessionMapped, onMapped);
-        var linkPolicy = u.deepMerge({
-          options: {
-            name: linkName,
-            source: { address: 'localhost' },
-            target: { address: address }
-          }
-        }, self.policy.senderLink);
-        self._session.attachLink(linkPolicy);
+
+        var link = self._session.attachLink(linkPolicy);
+        link.on(Link.Attached, onAttached);
       };
 
       (self._session && self._session.mapped) ?
@@ -328,8 +326,6 @@ AMQPClient.prototype.createReceiver = function(address, options) {
   address = address || this._defaultQueue;
   options = options || {};
 
-  var self = this;
-
   var linkName = address + '_RX';
   var linkPolicy = u.deepMerge({
     options: {
@@ -337,7 +333,7 @@ AMQPClient.prototype.createReceiver = function(address, options) {
       source: { address: address },
       target: { address: 'localhost' }
     }
-  }, self.policy.receiverLink);
+  }, this.policy.receiverLink);
 
   if (options) {
     if (options.filter && options.filter instanceof Array && options[0] === 'map') {
@@ -351,6 +347,7 @@ AMQPClient.prototype.createReceiver = function(address, options) {
     }
   }
 
+  var self = this;
   return new Promise(function(resolve, reject) {
     // return cached link if it exists
     if (self._attached[linkName]) {
@@ -374,12 +371,8 @@ AMQPClient.prototype.createReceiver = function(address, options) {
 
     var attach = function() {
       var onAttached = function(link) {
-        if (link.name !== linkName) {
-          return;
-        }
-
         debug('receiver link attached: ' + link.name);
-        self.removeListener(AMQPClient.LinkAttached, onAttached);
+        link.removeListener(Link.Attached, onAttached);
         self._attached[linkName] = link;
 
         link.on(Link.Detached, function(details) {
@@ -394,11 +387,11 @@ AMQPClient.prototype.createReceiver = function(address, options) {
         resolve(link);
       };
 
-      self.on(AMQPClient.LinkAttached, onAttached);
-
       var onMapped = function() {
         self.removeListener(AMQPClient.SessionMapped, onMapped);
-        self._session.attachLink(linkPolicy);
+
+        var link = self._session.attachLink(linkPolicy);
+        link.on(Link.Attached, onAttached);
       };
 
       (self._session && self._session.mapped) ?

--- a/test/unit/mocks/session.js
+++ b/test/unit/mocks/session.js
@@ -12,6 +12,7 @@ function MockSession(conn) {
 util.inherits(MockSession, EventEmitter);
 
 MockSession.prototype.begin = function(policy) {
+  this.mapped = true;
   this.emit('begin-called', this, policy);
 };
 

--- a/test/unit/mocks/session.js
+++ b/test/unit/mocks/session.js
@@ -12,17 +12,18 @@ function MockSession(conn) {
 util.inherits(MockSession, EventEmitter);
 
 MockSession.prototype.begin = function(policy) {
-  this.mapped = true;
   this.emit('begin-called', this, policy);
 };
 
 MockSession.prototype.attachLink = function(policy) {
   var link = this._mockLinks[policy.options.name];
   expect(link).to.exist;
+
   link._created++;
   link._clearState();
   link.attached = true;
   this.emit('attachLink-called', this, policy, link);
+  return link;
 };
 
 MockSession.prototype._addMockLink = function(link) {

--- a/test/unit/test_amqpclient.js
+++ b/test/unit/test_amqpclient.js
@@ -37,6 +37,8 @@ describe('AMQPClient', function() {
 
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
+
+        _s.mapped = true;
         _s.emit(Session.Mapped, _s);
       });
 
@@ -79,6 +81,8 @@ describe('AMQPClient', function() {
 
       s.on('begin-called', function (_s, _policy) {
         called.begin++;
+
+        _s.mapped = true;
         _s.emit(Session.Mapped, _s);
       });
 
@@ -87,7 +91,10 @@ describe('AMQPClient', function() {
         expect(_policy.options.target).to.eql({address: queue});
         expect(_policy.options.role).to.eql(constants.linkRole.sender);
 
-        _s.emit(Session.LinkAttached, _l);
+        process.nextTick(function() {
+          _l.emit(Link.Attached, _l);
+          _s.emit(Session.LinkAttached, _l);
+        });
       });
 
       l.on('canSend-called', function () {
@@ -148,6 +155,8 @@ describe('AMQPClient', function() {
       setTimeout(function() {
         self.emit('attachLink-called', self, policy, link);
       }, 100);
+
+      return link;
     };
 
     it('should return cached receiver links upon multiple createReceive calls', function() {
@@ -173,6 +182,8 @@ describe('AMQPClient', function() {
 
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
+
+        _s.mapped = true;
         _s.emit(Session.Mapped, _s);
       });
 
@@ -180,7 +191,11 @@ describe('AMQPClient', function() {
         called.attachLink++;
         expect(_policy.options.source).to.eql({ address: queue });
         expect(_policy.options.role).to.eql(constants.linkRole.receiver);
-        _s.emit(Session.LinkAttached, _l);
+
+        process.nextTick(function() {
+          _l.emit(Link.Attached, _l);
+          _s.emit(Session.LinkAttached, _l);
+        });
       });
 
       var originalLink;
@@ -232,6 +247,8 @@ describe('AMQPClient', function() {
 
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
+
+        _s.mapped = true;
         _s.emit(Session.Mapped, _s);
       });
 
@@ -239,7 +256,11 @@ describe('AMQPClient', function() {
         called.attachLink++;
         expect(_policy.options.source).to.eql({ address: queue });
         expect(_policy.options.role).to.eql(constants.linkRole.receiver);
-        _s.emit(Session.LinkAttached, _l);
+
+        process.nextTick(function() {
+          _l.emit(Link.Attached, _l);
+          _s.emit(Session.LinkAttached, _l);
+        });
       });
 
       return client.connect(mock_uri)
@@ -286,13 +307,19 @@ describe('AMQPClient', function() {
 
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
+
+        _s.mapped = true;
         _s.emit(Session.Mapped, _s);
       });
 
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         expect(_policy.options.role).to.eql(constants.linkRole.receiver);
-        _s.emit(Session.LinkAttached, _l);
+
+        process.nextTick(function() {
+          _l.emit(Link.Attached, _l);
+          _s.emit(Session.LinkAttached, _l);
+        });
       });
 
       return client.connect(mock_uri)
@@ -336,6 +363,8 @@ describe('AMQPClient', function() {
 
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
+
+        _s.mapped = true;
         _s.emit(Session.Mapped, _s);
       });
 
@@ -349,7 +378,11 @@ describe('AMQPClient', function() {
             _s.emit(Session.LinkDetached, _l);
           });
         }
-        _s.emit(Session.LinkAttached, _l);
+
+        process.nextTick(function() {
+          _l.emit(Link.Attached, _l);
+          _s.emit(Session.LinkAttached, _l);
+        });
       });
 
       return client.connect(mock_uri)
@@ -391,6 +424,8 @@ describe('AMQPClient', function() {
 
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
+
+        _s.mapped = true;
         _s.emit(Session.Mapped, _s);
       });
 
@@ -404,7 +439,10 @@ describe('AMQPClient', function() {
           });
         }
 
-        _s.emit(Session.LinkAttached, _l);
+        process.nextTick(function() {
+          _l.emit(Link.Attached, _l);
+          _s.emit(Session.LinkAttached, _l);
+        });
       });
 
       return client.connect(mock_uri)


### PR DESCRIPTION
The general idea here was to expose how similar createSender and createReceiver actually were. By cleaning up, and refactoring these methods, it's pretty clear that they share most of the same code. Additionally, I opted to listen directly to created links for events like `Link.Attached` in order to get around issues we had previously with needing to do string checks for incoming attached events.