### PR TITLE
refactor(links): move responsibility of Links fully to Session

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -91,9 +91,6 @@ AMQPClient.ErrorReceived = 'client:errorReceived'; // Called with error
 AMQPClient.ConnectionOpened = 'connection:opened';
 AMQPClient.ConnectionClosed = 'connection:closed';
 
-AMQPClient.SessionMapped = 'session:mapped';
-AMQPClient.SessionUnmapped = 'session:unmapped';
-
 
 /**
  * Exposes various AMQP-related constants, for use in policy overrides.
@@ -143,26 +140,15 @@ AMQPClient.prototype.connect = function(url) {
       self._session.on(Session.Mapped, function(s) {
         debug('mapped');
         resolve(self);
-        self.emit(AMQPClient.SessionMapped);
       });
 
       self._session.on(Session.Unmapped, function(s) {
         debug('unmapped');
-        self.emit(AMQPClient.SessionUnmapped);
       });
 
       self._session.on(Session.ErrorReceived, function(e) {
         debug('session error: ', e);
         self.emit(AMQPClient.ErrorReceived, e);
-      });
-
-      self._session.on(Session.LinkAttached, function(l) {
-        self.emit(AMQPClient.LinkAttached, l);
-      });
-
-      self._session.on(Session.LinkDetached, function(l) {
-        debug('link detached: ' + l.name);
-        self.emit(AMQPClient.LinkDetached, l);
       });
 
       self._session.begin(self.policy.session);
@@ -285,14 +271,14 @@ AMQPClient.prototype.createSender = function(address, options) {
       };
 
       var onMapped = function() {
-        self.removeListener(AMQPClient.SessionMapped, onMapped);
+        self._session.removeListener(Session.Mapped, onMapped);
 
         var link = self._session.attachLink(linkPolicy);
         link.on(Link.Attached, onAttached);
       };
 
       (self._session && self._session.mapped) ?
-        onMapped() : self.on(AMQPClient.SessionMapped, onMapped);
+        onMapped() : self._session.on(Session.Mapped, onMapped);
     };
 
     self._reattach[linkName] = attach;
@@ -391,14 +377,14 @@ AMQPClient.prototype.createReceiver = function(address, options) {
       };
 
       var onMapped = function() {
-        self.removeListener(AMQPClient.SessionMapped, onMapped);
+        self._session.removeListener(Session.Mapped, onMapped);
 
         var link = self._session.attachLink(linkPolicy);
         link.on(Link.Attached, onAttached);
       };
 
       (self._session && self._session.mapped) ?
-        onMapped() : self.on(AMQPClient.SessionMapped, onMapped);
+        onMapped() : self._session.on(Session.Mapped, onMapped);
     };
 
     self._reattach[linkName] = attach;

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -208,7 +208,7 @@ AMQPClient.prototype.createSender = function(address, options) {
   return new Promise(function(resolve, reject) {
     var attach = function() {
       var link = self._session._senderLinks[linkName];
-      if (link && link.attached) {
+      if (link && link.state() === 'attached') {
         return resolve(link);
       }
 
@@ -277,7 +277,7 @@ AMQPClient.prototype.createReceiver = function(address, options) {
   return new Promise(function(resolve, reject) {
     var attach = function() {
       var link = self._session._receiverLinks[linkName];
-      if (link && link.attached) {
+      if (link && link.state() === 'attached') {
         return resolve(link);
       }
 

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -73,12 +73,9 @@ function AMQPClient(policy) {
   this.policy = u.deepMerge(this._originalPolicy);
   this._connection = null;
   this._session = null;
-  this._attaching = {};
-  this._senderAttaching = {};
-  this._attached = {};
 
-  this._reconnect = null;
   this._reattach = {};
+  this._reconnect = null;
   if (!!this.policy.reconnect) {
     this._timeouts = u.generateTimeouts(this.policy.reconnect);
   }
@@ -181,26 +178,6 @@ AMQPClient.prototype.connect = function(url) {
   });
 };
 
-AMQPClient.prototype._resolveDeferredSenderAttaches = function(linkName, err, link) {
-  // resolve deferred attachments
-  while (this._senderAttaching[linkName].length) {
-    var deferredAttach = this._senderAttaching[linkName].shift();
-    deferredAttach(err, link);
-  }
-
-  this._senderAttaching[linkName] = undefined;
-};
-
-AMQPClient.prototype._resolveDeferredReceiverAttaches = function(linkName, err, link) {
-  // resolve deferred attachments
-  while (this._attaching[linkName].length) {
-    var deferredAttach = this._attaching[linkName].shift();
-    deferredAttach(err, link);
-  }
-
-  this._attaching[linkName] = undefined;
-};
-
 /**
  * Creates a sender link for the given address, with optional link options
  *
@@ -227,63 +204,27 @@ AMQPClient.prototype.createSender = function(address, options) {
     }
   }, this.policy.senderLink);
 
-
   var self = this;
   return new Promise(function(resolve, reject) {
-    // return cached link if it exists
-    if (self._attached[linkName]) {
-      return resolve(self._attached[linkName]);
-    }
-
-    // return deferred attach promise if already attaching
-    if (self._senderAttaching[linkName]) {
-      var deferredAttach = function(err, link) {
-        if (!!err) return reject(err);
-        return resolve(link);
-      };
-
-      self._senderAttaching[linkName].push(deferredAttach);
-      return;
-    }
-
-    // otherwise set some initial state for the link.
-    if (self._attached[linkName] === undefined) self._attached[linkName] = null;
-    if (self._senderAttaching[linkName] === undefined) self._senderAttaching[linkName] = [];
-
     var attach = function() {
-      var onAttached = function(link) {
-        debug('sender link attached: ' + linkName);
-        link.removeListener(Link.Attached, onAttached);
-        self._attached[linkName] = link;
+      var link = self._session._senderLinks[linkName];
+      if (link && link.attached) {
+        return resolve(link);
+      }
 
-        link.on(Link.ErrorReceived, function(err) {
-          self.emit(AMQPClient.ErrorReceived, err);
-        });
+      if (!link) {
+        link = self._session.createLink(linkPolicy);
+      }
 
-        link.on(Link.Detached, function(details) {
-          debug('sender link detached: ' + (details ? details.error : 'No details'));
-          self._attached[linkName] = undefined;
-        });
-
-        // return the attached link
-        self._resolveDeferredSenderAttaches(linkName, null, link);
-        resolve(link);
+      var attachPromise = function(_err, _link) {
+        if (!!_err) return reject(_err);
+        return resolve(_link);
       };
 
-      var onMapped = function() {
-        self._session.removeListener(Session.Mapped, onMapped);
-
-        var link = self._session.attachLink(linkPolicy);
-        link.on(Link.Attached, onAttached);
-      };
-
-      (self._session && self._session.mapped) ?
-        onMapped() : self._session.on(Session.Mapped, onMapped);
+      link._onAttach.push(attachPromise);
     };
 
     self._reattach[linkName] = attach;
-
-    // attempt to attach the link
     attach();
   });
 };
@@ -334,62 +275,25 @@ AMQPClient.prototype.createReceiver = function(address, options) {
 
   var self = this;
   return new Promise(function(resolve, reject) {
-    // return cached link if it exists
-    if (self._attached[linkName]) {
-      return resolve(self._attached[linkName]);
-    }
-
-    // return deferred attach promise if already attaching
-    if (self._attaching[linkName]) {
-      var deferredAttach = function(err, link) {
-        if (!!err) return reject(err);
-        return resolve(link);
-      };
-
-      self._attaching[linkName].push(deferredAttach);
-      return;
-    }
-
-    // otherwise create the link, and set initial state
-    if (self._attached[linkName] === undefined) self._attached[linkName] = null;
-    if (self._attaching[linkName] === undefined) self._attaching[linkName] = [];
-
     var attach = function() {
-      var onAttached = function(link) {
-        debug('receiver link attached: ' + link.name);
-        link.removeListener(Link.Attached, onAttached);
-        self._attached[linkName] = link;
+      var link = self._session._receiverLinks[linkName];
+      if (link && link.attached) {
+        return resolve(link);
+      }
 
-        link.on(Link.ErrorReceived, function(err) {
-          self.emit(AMQPClient.ErrorReceived, err);
-        });
+      if (!link) {
+        link = self._session.createLink(linkPolicy);
+      }
 
-        link.on(Link.Detached, function(details) {
-          debug('link detached: ' + (details ? details.error : 'No details'));
-          self._attached[linkName] = undefined;
-
-          // @todo: investigate options/policies for auto-reattach
-          // attach();
-        });
-
-        self._resolveDeferredReceiverAttaches(linkName, null, link);
-        resolve(link);
+      var attachPromise = function(_err, _link) {
+        if (!!_err) return reject(_err);
+        return resolve(_link);
       };
 
-      var onMapped = function() {
-        self._session.removeListener(Session.Mapped, onMapped);
-
-        var link = self._session.attachLink(linkPolicy);
-        link.on(Link.Attached, onAttached);
-      };
-
-      (self._session && self._session.mapped) ?
-        onMapped() : self._session.on(Session.Mapped, onMapped);
+      link._onAttach.push(attachPromise);
     };
 
     self._reattach[linkName] = attach;
-
-    // attempt to attach the link
     attach();
   });
 };
@@ -420,11 +324,9 @@ AMQPClient.prototype.disconnect = function() {
 };
 
 AMQPClient.prototype._clearConnectionState = function(saveReconnectDetails) {
-  this._attached = {};
-  this._attaching = {};
-  this._senderAttaching = {};
   this._connection = null;
   this._session = null;
+
   // Copy from original to avoid any settings changes "sticking" across connections.
   this.policy = u.deepMerge(this._originalPolicy);
 
@@ -444,8 +346,8 @@ AMQPClient.prototype._newSession = function(conn) {
 };
 
 AMQPClient.prototype._preventReconnect = function() {
-  this._reconnect = null;
   this._reattach = {};
+  this._reconnect = null;
 };
 
 AMQPClient.prototype._shouldReconnect = function() {

--- a/lib/link.js
+++ b/lib/link.js
@@ -22,6 +22,8 @@ function Link(session, handle, linkPolicy) {
   this.attached = false;
   this.remoteHandle = undefined;
 
+  this._onAttach = [];
+
   var self = this;
   var stateMachine = {
     'DETACHED': {
@@ -69,14 +71,14 @@ Link.MessageReceived = 'message';
 Link.ErrorReceived = 'error';
 
 // On link credit changed.
-Link.CreditChange = 'link:creditChange';
+Link.CreditChange = 'creditChange';
 
 
 // On completion of detach.
-Link.Attached = 'link:attached';
+Link.Attached = 'attached';
 
 // On completion of detach.
-Link.Detached = 'link:detached';
+Link.Detached = 'detached';
 
 // public api
 Link.prototype.attach = function() {
@@ -113,6 +115,13 @@ Link.prototype.detach = function() {
 };
 
 // private api
+Link.prototype._resolveAttachPromises = function(err, link) {
+  while (this._onAttach.length) {
+    var attachPromise = this._onAttach.shift();
+    attachPromise(err, link);
+  }
+};
+
 Link.prototype._attachReceived = function(attachFrame) {
   this.linkSM.attachReceived();
   // process params.
@@ -121,12 +130,10 @@ Link.prototype._attachReceived = function(attachFrame) {
   debug('Rx attach CH=[' + this.session.channel + '=>' + attachFrame.channel + '], Handle=[' + this.handle + '=>' + attachFrame.handle + ']');
   this.attached = true;
 
-  // @todo: Session should listen for Link.Attached
-  this.session._linkAttached(this);
+  this.emit(Link.Attached, this);
+  this._resolveAttachPromises(null, this);
 
   this._checkCredit();
-
-  this.emit(Link.Attached, this);
 };
 
 // default implementation does nothing
@@ -151,17 +158,16 @@ Link.prototype._detached = function(frame) {
   }
 
   if (this.remoteHandle !== undefined) {
-    this.session._linksByRemoteHandle[this.remoteHandle] = undefined;
+    delete this.session._linksByRemoteHandle[this.remoteHandle];
     this.remoteHandle = undefined;
   }
 
-  this.session._linksByName[this.policy.options.name] = undefined;
-  this.session._allocatedHandles[this.policy.options.handle] = undefined;
+  delete this.session._linksByName[this.policy.options.name];
+  delete this.session._allocatedHandles[this.policy.options.handle];
   this.attached = false;
-  this.emit(Link.Detached, { closed: frame.closed, error: frame.error });
 
-  // @todo: Session should listen for Link.Detached
-  this.session._linkDetached(this);
+  this.emit(Link.Detached, { closed: frame.closed, error: frame.error });
+  this._resolveAttachPromises(frame.error ? frame.error : 'link closed');
 };
 
 module.exports = Link;

--- a/lib/link.js
+++ b/lib/link.js
@@ -19,7 +19,6 @@ function Link(session, handle, linkPolicy) {
   this.policy = linkPolicy;
   this.session = session;
   this.handle = handle;
-  this.attached = false;
   this.remoteHandle = undefined;
 
   this._onAttach = [];
@@ -68,7 +67,7 @@ Link.MessageReceived = 'message';
 // Since 'error' events are "special" in Node (as in halt-the-process special),
 // using a custom event for errors we receive from the other endpoint. Provides
 // received AMQPError as an argument.
-Link.ErrorReceived = 'error';
+Link.ErrorReceived = 'errorReceived';
 
 // On link credit changed.
 Link.CreditChange = 'creditChange';
@@ -80,11 +79,15 @@ Link.Attached = 'attached';
 Link.Detached = 'detached';
 
 // public api
+Link.prototype.state = function() {
+  return this.linkSM.getMachineState().toLowerCase();
+};
+
 Link.prototype.attach = function() {
   this.linkSM.sendAttach();
   var attachFrame = new AttachFrame(this.policy.options);
   attachFrame.channel = this.session.channel;
-  debug('Tx attach CH=' + attachFrame.channel + ', Handle=' + attachFrame.handle);
+  debug('attach CH=' + attachFrame.channel + ', Handle=' + attachFrame.handle);
 
   this.name = attachFrame.name;
   this.role = attachFrame.role;
@@ -123,11 +126,11 @@ Link.prototype._resolveAttachPromises = function(err, link) {
 
 Link.prototype._attachReceived = function(attachFrame) {
   this.linkSM.attachReceived();
+
   // process params.
   this.remoteHandle = attachFrame.handle;
   this.session._linksByRemoteHandle[this.remoteHandle] = this;
-  debug('Rx attach CH=[' + this.session.channel + '=>' + attachFrame.channel + '], Handle=[' + this.handle + '=>' + attachFrame.handle + ']');
-  this.attached = true;
+  debug('attached CH=[' + this.session.channel + '=>' + attachFrame.channel + '], Handle=[' + this.handle + '=>' + attachFrame.handle + ']');
 
   this.emit(Link.Attached, this);
   this._resolveAttachPromises(null, this);
@@ -163,7 +166,6 @@ Link.prototype._detached = function(frame) {
 
   delete this.session._linksByName[this.policy.options.name];
   delete this.session._allocatedHandles[this.policy.options.handle];
-  this.attached = false;
 
   this.emit(Link.Detached, { closed: frame.closed, error: frame.error });
   this._resolveAttachPromises(frame.error ? frame.error : 'link closed');

--- a/lib/link.js
+++ b/lib/link.js
@@ -73,7 +73,6 @@ Link.ErrorReceived = 'error';
 // On link credit changed.
 Link.CreditChange = 'creditChange';
 
-
 // On completion of detach.
 Link.Attached = 'attached';
 

--- a/lib/sender_link.js
+++ b/lib/sender_link.js
@@ -89,7 +89,7 @@ SenderLink.prototype.send = function(msg, options) {
       }
     };
 
-    if (!self.attached || !self.canSend()) {
+    if (self.state() !== 'attached' || !self.canSend()) {
       self._pendingSends.push(sendMessage);
       return;
     }

--- a/lib/sender_link.js
+++ b/lib/sender_link.js
@@ -33,7 +33,12 @@ SenderLink.prototype.attach = function() {
 };
 
 SenderLink.prototype.canSend = function() {
-  var sendable = (this.linkCredit >= 1 && (!this.session.policy.enableSessionFlowControl || this.session._sessionParams.remoteIncomingWindow >= 1));
+  if (this.state() !== 'attached') {
+    return false;
+  }
+
+  var sendable = this.linkCredit >= 1 &&
+    (!this.session.policy.enableSessionFlowControl || this.session._sessionParams.remoteIncomingWindow >= 1);
   debug('canSend(' + this.linkCredit + ',' + this.session._sessionParams.remoteIncomingWindow + ') = ' + sendable);
   return sendable;
 };
@@ -89,7 +94,7 @@ SenderLink.prototype.send = function(msg, options) {
       }
     };
 
-    if (self.state() !== 'attached' || !self.canSend()) {
+    if (!self.canSend()) {
       self._pendingSends.push(sendMessage);
       return;
     }

--- a/lib/session.js
+++ b/lib/session.js
@@ -169,23 +169,17 @@ function Session(conn) {
 util.inherits(Session, EventEmitter);
 
 // Events
-Session.Mapped = 'session:mapped';
-Session.Unmapped = 'session:unmapped';
+Session.Mapped = 'mapped';
+Session.Unmapped = 'unmapped';
 
 // Since 'error' events are "special" in Node (as in halt-the-process special),
 // using a custom event for errors we receive from the other endpoint. Provides
 // received AMQPError as an argument.
-Session.ErrorReceived = 'session:errorReceived';
-
-// On successful attach, Link given as argument.
-Session.LinkAttached = 'session:linkAttached';
-
-// On completion of detach, Link given as argument.
-Session.LinkDetached = 'session:linkDetached';
+Session.ErrorReceived = 'errorReceived';
 
 // On receipt of a disposition frame, called with the first and last
 // delivery-ids involved, whether they were settled, and the state.
-Session.DispositionReceived = 'session:dispositionReceived';
+Session.DispositionReceived = 'disposition';
 
 Session.prototype.begin = function(sessionPolicy) {
   var sessionParams = u.deepMerge(sessionPolicy.options);
@@ -225,14 +219,6 @@ Session.prototype.attachLink = function(linkPolicy) {
   this._linksByName[policy.options.name] = link;
   link.attach();
   return link;
-};
-
-Session.prototype._linkAttached = function(link) {
-  this.emit(Session.LinkAttached, link);
-};
-
-Session.prototype._linkDetached = function(link) {
-  this.emit(Session.LinkDetached, link);
 };
 
 Session.prototype.addWindow = function(windowSize, flowOptions) {

--- a/lib/session.js
+++ b/lib/session.js
@@ -121,8 +121,8 @@ function Session(conn) {
   this._linksByRemoteHandle = {};
   this._deliveryTag = 1;
 
-  this._senderLinks = [];
-  this._receiverLinks = [];
+  this._senderLinks = {};
+  this._receiverLinks = {};
 
   var self = this;
   var stateMachine = {
@@ -199,7 +199,7 @@ Session.prototype.begin = function(sessionPolicy) {
   this.connection.sendFrame(beginFrame);
 };
 
-Session.prototype.attachLink = function(linkPolicy) {
+Session.prototype.createLink = function(linkPolicy) {
   var policy = u.deepMerge(linkPolicy);
 
   policy.options.handle = this._nextHandle();
@@ -209,15 +209,34 @@ Session.prototype.attachLink = function(linkPolicy) {
   var link;
   if (policy.options.role === constants.linkRole.sender) {
     link = new SenderLink(this, policy.options.handle, policy);
-    this._senderLinks.push(link);
+    this._senderLinks[policy.options.name] = link;
   } else {
     link = new ReceiverLink(this, policy.options.handle, policy);
-    this._receiverLinks.push(link);
+    this._receiverLinks[policy.options.name] = link;
   }
 
   this._allocatedHandles[policy.options.handle] = link;
   this._linksByName[policy.options.name] = link;
-  link.attach();
+
+  var self = this;
+  link.on(Link.Detached, function(details) {
+    debug('detached(' + link.name + '): ' + (details ? details.error : 'No details'));
+    if (policy.options.role === constants.linkRole.sender) {
+      self._senderLinks[link.name] = undefined;
+    } else {
+      self._receiverLinks[link.name] = undefined;
+    }
+  });
+
+  link.on(Link.ErrorReceived, function(err) {
+    self.emit(Session.ErrorReceived , err);
+  });
+
+  if (this.mapped) {
+    // immediately attempt to attach link
+    link.attach();
+  }
+
   return link;
 };
 
@@ -308,7 +327,7 @@ Session.prototype._processFrame = function(frame) {
         console.warn('received Flow for unknown link(' + frame.handle + '): ' + JSON.stringify(frame));
       }
     } else {
-      this._senderLinks.forEach(function (senderLink) {
+      _.values(this._senderLinks).forEach(function (senderLink) {
         senderLink._flowReceived(frame);
       });
     }
@@ -340,6 +359,10 @@ Session.prototype._beginReceived = function(frame) {
   this.mapped = true;
   this._deliveryTag = 1;
   this.emit(Session.Mapped, this);
+
+  // attach all links
+  _.values(this._senderLinks).forEach(function(l) { l.attach(); });
+  _.values(this._receiverLinks).forEach(function(l) { l.attach(); });
 };
 
 Session.prototype._flowReceived = function(frame) {
@@ -405,9 +428,9 @@ Session.prototype._handleDisposition = function(frame) {
 
   var dispositionHandler = function(l) { l._dispositionReceived(disposition); };
   if (frame.role === constants.linkRole.sender) {
-    this._receiverLinks.forEach(dispositionHandler);
+    _.values(this._receiverLinks).forEach(dispositionHandler);
   } else {
-    this._senderLinks.forEach(dispositionHandler);
+    _.values(this._senderLinks).forEach(dispositionHandler);
   }
 
   this.emit(Session.DispositionReceived, disposition);

--- a/lib/session.js
+++ b/lib/session.js
@@ -361,8 +361,11 @@ Session.prototype._beginReceived = function(frame) {
   this.emit(Session.Mapped, this);
 
   // attach all links
-  _.values(this._senderLinks).forEach(function(l) { l.attach(); });
-  _.values(this._receiverLinks).forEach(function(l) { l.attach(); });
+  var attachHandler = function(l) {
+    if (l.state() !== 'attached' && l.state() !== 'attaching') l.attach();
+  };
+  _.values(this._senderLinks).forEach(attachHandler);
+  _.values(this._receiverLinks).forEach(attachHandler);
 };
 
 Session.prototype._flowReceived = function(frame) {

--- a/test/unit/mocks/receiver_link.js
+++ b/test/unit/mocks/receiver_link.js
@@ -1,15 +1,19 @@
 'use strict';
-var EventEmitter = require('events').EventEmitter,
+var Link = require('../../../lib/link'),
+    ReceiverLink = require('../../../lib/receiver_link'),
+
     util = require('util');
 
 function MockReceiverLink(session, options) {
+  MockReceiverLink.super_.call(this);
+
   this._created = 0;
   this.session = session;
   this.options = options;
   this._clearState();
 }
 
-util.inherits(MockReceiverLink, EventEmitter);
+util.inherits(MockReceiverLink, ReceiverLink);
 
 MockReceiverLink.prototype._clearState = function() {
   this.name = this.options.name;
@@ -18,5 +22,13 @@ MockReceiverLink.prototype._clearState = function() {
   this.messages = [];
   this.curId = 0;
 };
+
+MockReceiverLink.prototype.simulateAttaching = function() {
+  this.linkSM.sendAttach();
+  this.linkSM.attachReceived();
+  this.emit(Link.Attached, this);
+  this._resolveAttachPromises(null, this);
+};
+
 
 module.exports = MockReceiverLink;

--- a/test/unit/mocks/sender_link.js
+++ b/test/unit/mocks/sender_link.js
@@ -1,5 +1,7 @@
 'use strict';
-var SenderLink = require('../../../lib/sender_link'),
+var Link = require('../../../lib/link'),
+    SenderLink = require('../../../lib/sender_link'),
+
     putils = require('../../../lib/policies/policy_utilities'),
     util = require('util');
 
@@ -36,6 +38,13 @@ MockSenderLink.prototype._clearState = function() {
   this.capacity = this.options.capacity || 0;
   this.messages = [];
   this.curId = 0;
+};
+
+MockSenderLink.prototype.simulateAttaching = function() {
+  this.linkSM.sendAttach();
+  this.linkSM.attachReceived();
+  this.emit(Link.Attached, this);
+  this._resolveAttachPromises(null, this);
 };
 
 module.exports = MockSenderLink;

--- a/test/unit/mocks/session.js
+++ b/test/unit/mocks/session.js
@@ -1,21 +1,24 @@
 'use strict';
-var EventEmitter = require('events').EventEmitter,
+var Session = require('../../../lib/session'),
+
     expect = require('chai').expect,
     util = require('util');
 
 function MockSession(conn) {
+  MockSession.super_.call(this);
+
   this._created = 0;
   this.connection = conn;
   this._mockLinks = {};
 }
 
-util.inherits(MockSession, EventEmitter);
+util.inherits(MockSession, Session);
 
 MockSession.prototype.begin = function(policy) {
   this.emit('begin-called', this, policy);
 };
 
-MockSession.prototype.attachLink = function(policy) {
+MockSession.prototype.createLink = function(policy) {
   var link = this._mockLinks[policy.options.name];
   expect(link).to.exist;
 

--- a/test/unit/test_amqpclient.js
+++ b/test/unit/test_amqpclient.js
@@ -92,8 +92,7 @@ describe('AMQPClient', function() {
         expect(_policy.options.role).to.eql(constants.linkRole.sender);
 
         process.nextTick(function() {
-          _l.emit(Link.Attached, _l);
-          _s.emit(Session.LinkAttached, _l);
+          _l.simulateAttaching();
         });
       });
 
@@ -193,8 +192,7 @@ describe('AMQPClient', function() {
         expect(_policy.options.role).to.eql(constants.linkRole.receiver);
 
         process.nextTick(function() {
-          _l.emit(Link.Attached, _l);
-          _s.emit(Session.LinkAttached, _l);
+          _l.simulateAttaching();
         });
       });
 
@@ -258,8 +256,7 @@ describe('AMQPClient', function() {
         expect(_policy.options.role).to.eql(constants.linkRole.receiver);
 
         process.nextTick(function() {
-          _l.emit(Link.Attached, _l);
-          _s.emit(Session.LinkAttached, _l);
+          _l.simulateAttaching();
         });
       });
 
@@ -317,8 +314,7 @@ describe('AMQPClient', function() {
         expect(_policy.options.role).to.eql(constants.linkRole.receiver);
 
         process.nextTick(function() {
-          _l.emit(Link.Attached, _l);
-          _s.emit(Session.LinkAttached, _l);
+          _l.simulateAttaching();
         });
       });
 
@@ -380,8 +376,7 @@ describe('AMQPClient', function() {
         }
 
         process.nextTick(function() {
-          _l.emit(Link.Attached, _l);
-          _s.emit(Session.LinkAttached, _l);
+          _l.simulateAttaching();
         });
       });
 
@@ -440,8 +435,7 @@ describe('AMQPClient', function() {
         }
 
         process.nextTick(function() {
-          _l.emit(Link.Attached, _l);
-          _s.emit(Session.LinkAttached, _l);
+          _l.simulateAttaching();
         });
       });
 

--- a/test/unit/test_session.js
+++ b/test/unit/test_session.js
@@ -206,8 +206,9 @@ describe('Session', function() {
       var actual = {};
       var assertMultipleTransitions = function(name, transitions) {
         actual[name] = transitions;
-        if (_.isEqual(expected, actual))
+        if (_.isEqual(expected, actual)) {
           done();
+        }
       };
 
       connection.connSM.bind(tu.assertTransitions(expected.connection, function(transitions) {
@@ -222,8 +223,8 @@ describe('Session', function() {
 
         session.on(Session.Mapped, function() {
           var opts = u.deepMerge({ options: { name: 'test', source: src(), target: tgt() } }, DefaultPolicy.senderLink);
-          var link = session.attachLink(opts);
-          link.on('error', function(err) {
+          var link = session.createLink(opts);
+          link.on('errorReceived', function(err) {
             expect(err).to.eql(new AMQPError(AMQPError.LinkDetachForced, 'test', ''));
           });
 


### PR DESCRIPTION
There are some cleanups here (removing events that shouldn't be used anymore, generally going back on my stupid decision to put namespaces in event names, etc), but more importantly is the change to remove attaching/attached tracking for links inside AMQPClient. It is now the responsibility of a Session to track Link state, and the Client's create[Sender,Receiver] methods are merely proxies at this point to Session.createLink.