### PR TITLE
feat(unique-link-names): use uniquely generated link names

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -195,19 +195,22 @@ AMQPClient.prototype.createSender = function(address, options) {
   address = address || this._defaultQueue;
   options = options || {};
 
-  var linkName = address + '_TX';
-  var linkPolicy = u.deepMerge({
-    options: {
-      name: linkName,
-      source: { address: 'localhost' },
-      target: { address: address }
-    }
-  }, this.policy.senderLink);
+  var linkName = u.linkName(address, options),
+      linkPolicy = u.deepMerge({
+        options: {
+          name: linkName,
+          source: { address: 'localhost' },
+          target: { address: address }
+        }
+      }, this.policy.senderLink);
+
+  // store link id
+  linkPolicy.id = u.linkHash(address, options);
 
   var self = this;
   return new Promise(function(resolve, reject) {
     var attach = function() {
-      var link = self._session._senderLinks[linkName];
+      var link = self._session._senderLinks[linkPolicy.id];
       if (link && link.state() === 'attached') {
         return resolve(link);
       }
@@ -224,7 +227,7 @@ AMQPClient.prototype.createSender = function(address, options) {
       link._onAttach.push(attachPromise);
     };
 
-    self._reattach[linkName] = attach;
+    self._reattach[linkPolicy.id] = attach;
     attach();
   });
 };
@@ -252,14 +255,14 @@ AMQPClient.prototype.createReceiver = function(address, options) {
   address = address || this._defaultQueue;
   options = options || {};
 
-  var linkName = address + '_RX';
-  var linkPolicy = u.deepMerge({
-    options: {
-      name: linkName,
-      source: { address: address },
-      target: { address: 'localhost' }
-    }
-  }, this.policy.receiverLink);
+  var linkName = u.linkName(address, options),
+      linkPolicy = u.deepMerge({
+        options: {
+          name: linkName,
+          source: { address: address },
+          target: { address: 'localhost' }
+        }
+      }, this.policy.receiverLink);
 
   if (options) {
     if (options.filter && options.filter instanceof Array && options[0] === 'map') {
@@ -273,10 +276,14 @@ AMQPClient.prototype.createReceiver = function(address, options) {
     }
   }
 
+  // store link id
+  linkPolicy.id = u.linkHash(address, options);
+
   var self = this;
   return new Promise(function(resolve, reject) {
     var attach = function() {
-      var link = self._session._receiverLinks[linkName];
+
+      var link = self._session._receiverLinks[linkPolicy.id];
       if (link && link.state() === 'attached') {
         return resolve(link);
       }
@@ -293,7 +300,7 @@ AMQPClient.prototype.createReceiver = function(address, options) {
       link._onAttach.push(attachPromise);
     };
 
-    self._reattach[linkName] = attach;
+    self._reattach[linkPolicy.id] = attach;
     attach();
   });
 };

--- a/lib/session.js
+++ b/lib/session.js
@@ -117,12 +117,16 @@ function Session(conn) {
   this.mapped = false;
   this.remoteChannel = undefined;
   this._allocatedHandles = {};
-  this._linksByName = {};
-  this._linksByRemoteHandle = {};
   this._deliveryTag = 1;
 
   this._senderLinks = {};
   this._receiverLinks = {};
+
+  this._linksByName = {};
+  this._linksByName[constants.linkRole.sender] = {};
+  this._linksByName[constants.linkRole.receiver] = {};
+  this._linksByRemoteHandle = {};
+
 
   var self = this;
   var stateMachine = {
@@ -209,22 +213,25 @@ Session.prototype.createLink = function(linkPolicy) {
   var link;
   if (policy.options.role === constants.linkRole.sender) {
     link = new SenderLink(this, policy.options.handle, policy);
-    this._senderLinks[policy.options.name] = link;
+    this._senderLinks[policy.id] = link;
   } else {
     link = new ReceiverLink(this, policy.options.handle, policy);
-    this._receiverLinks[policy.options.name] = link;
+    this._receiverLinks[policy.id] = link;
   }
 
   this._allocatedHandles[policy.options.handle] = link;
-  this._linksByName[policy.options.name] = link;
+
+  // NOTE: we need to store it in the opposite role because that's how we will
+  //       receive the corresponding attach frame from the broker
+  this._linksByName[!policy.options.role][policy.options.name] = link;
 
   var self = this;
   link.on(Link.Detached, function(details) {
     debug('detached(' + link.name + '): ' + (details ? details.error : 'No details'));
     if (policy.options.role === constants.linkRole.sender) {
-      self._senderLinks[link.name] = undefined;
+      delete self._senderLinks[policy.id];
     } else {
-      self._receiverLinks[link.name] = undefined;
+      delete self._receiverLinks[policy.id];
     }
   });
 
@@ -304,8 +311,8 @@ Session.prototype._processFrame = function(frame) {
     }
     this._unmap();
   } else if (frame instanceof AttachFrame) {
-    if (frame.name && this._linksByName[frame.name]) {
-      this._linksByName[frame.name]._attachReceived(frame);
+    if (frame.name && this._linksByName[frame.role][frame.name]) {
+      this._linksByName[frame.role][frame.name]._attachReceived(frame);
     } else {
       // @todo Proper error reporting.  Should we shut down session?
       console.warn('received Attach for unknown link(' + frame.name + '): ' + JSON.stringify(frame));

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -4,7 +4,10 @@ var _ = require('lodash'),
     debug = require('debug')('amqp10:utilities'),
 
     constants = require('./constants'),
-    errors = require('./errors');
+    errors = require('./errors'),
+
+    objectHash = require('object-hash'),
+    uuid = require('uuid');
 
 
 /**
@@ -253,7 +256,7 @@ module.exports.generateTimeouts = function(options) {
 /**
  * Calculates the start and end for a disposition frame
  *
- * @param message either a single message or an array of them
+ * @param message    either a single message or an array of them
  * @return {Object}
  */
 module.exports.dispositionRange = function(message) {
@@ -269,4 +272,26 @@ module.exports.dispositionRange = function(message) {
     first: first,
     last: last
   };
+};
+
+/**
+ * Generates a link name for a given address
+ *
+ * @param address   link address
+ * @param options   link creation options
+ * @return String
+ */
+module.exports.linkName = function(address, options) {
+  return ((!!options && !!options.name) ? options.name : address + '_' + uuid.v4());
+};
+
+/**
+ * Generates a hash for a given link address and options
+ *
+ * @param address   link address
+ * @param options   link creation options
+ * @return String
+ */
+module.exports.linkHash = function(address, options) {
+  return objectHash({ address: address, options: options });
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "istanbul": "^0.3.6",
     "jshint": "^2.6.0",
     "mocha": "^2.1.0",
+    "object-hash": "^0.8.0",
     "stream-buffers": "2.1.0",
     "qmf2": "^0.0.5"
   },

--- a/test/unit/test_amqpclient.js
+++ b/test/unit/test_amqpclient.js
@@ -106,7 +106,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function () {
-          return client.createSender(queue);
+          return client.createSender(queue, { name: 'queue_TX' });
         })
         .then(function (sender) {
           return Promise.all([
@@ -200,16 +200,16 @@ describe('AMQPClient', function() {
       return client.connect(mock_uri)
         .then(function() {
           // create but don't wait so we can simulate an attaching link
-          client.createReceiver(queue)
+          client.createReceiver(queue, { name: 'queue_RX' })
             .then(function(link) {
               originalLink = link;
             });
         })
         .then(function() {
           return Promise.all([
-            client.createReceiver(queue),
-            client.createReceiver(queue),
-            client.createReceiver(queue)
+            client.createReceiver(queue, { name: 'queue_RX' }),
+            client.createReceiver(queue, { name: 'queue_RX' }),
+            client.createReceiver(queue, { name: 'queue_RX' })
           ]);
         })
         .spread(function(link1, link2, link3) {
@@ -262,7 +262,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function() {
-          return client.createReceiver(queue);
+          return client.createReceiver(queue, { name: 'queue_RX' });
         })
         .then(function() {
           expect(c._created).to.eql(1);
@@ -321,8 +321,8 @@ describe('AMQPClient', function() {
       return client.connect(mock_uri)
         .then(function() {
           return Promise.all([
-            client.createReceiver('queue1'),
-            client.createReceiver('queue2')
+            client.createReceiver('queue1', { name: 'queue1_RX' }),
+            client.createReceiver('queue2', { name: 'queue2_RX' })
           ]);
         })
         .then(function() {
@@ -382,7 +382,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function() {
-          return client.createReceiver(queue);
+          return client.createReceiver(queue, { name: 'queue_RX' });
         })
         .then(function() {
           process.nextTick(function() {
@@ -441,7 +441,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function() {
-          return client.createReceiver(queue);
+          return client.createReceiver(queue, { name: 'queue_RX' });
         })
         .then(function() {
           process.nextTick(function() {


### PR DESCRIPTION
This follows more closely to what QPID is doing with their messaging framework, in that link names by default are generated based on their address (and in our case link creation properties). A hash of the address and options is used to uniquely identify an attempt to recreate an existing receiver. The user is still able to override this behavior by passing in a "name" parameter to the link creation "options" object (verified in the unit tests)