### PR TITLE
feat(default-subject): allow specifying subjects in link names

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -192,17 +192,21 @@ AMQPClient.prototype.createSender = function(address, options) {
     throw new Error('Must connect before creating links');
   }
 
-  address = address || this._defaultQueue;
+  address = u.parseLinkAddress(address || this._defaultQueue);
   options = options || {};
 
-  var linkName = u.linkName(address, options),
+  var linkName = u.linkName(address.name, options),
       linkPolicy = u.deepMerge({
         options: {
           name: linkName,
           source: { address: 'localhost' },
-          target: { address: address }
+          target: { address: address.name }
         }
       }, this.policy.senderLink);
+
+  if (!!address.subject && this.policy.defaultSubjects) {
+    linkPolicy.defaultSubject = address.subject;
+  }
 
   var self = this;
   return new Promise(function(resolve, reject) {
@@ -241,14 +245,14 @@ AMQPClient.prototype.createReceiver = function(address, options) {
     throw new Error('Must connect before creating links');
   }
 
-  address = address || this._defaultQueue;
+  address = u.parseLinkAddress(address || this._defaultQueue);
   options = options || {};
 
-  var linkName = u.linkName(address, options),
+  var linkName = u.linkName(address.name, options),
       linkPolicy = u.deepMerge({
         options: {
           name: linkName,
-          source: { address: address },
+          source: { address: address.name },
           target: { address: 'localhost' }
         }
       }, this.policy.receiverLink);
@@ -263,6 +267,18 @@ AMQPClient.prototype.createReceiver = function(address, options) {
     if (options.policy) {
       linkPolicy = u.deepMerge(linkPolicy, options.policy);
     }
+  }
+
+  // if a subject has been provided then automatically set up a filter to match
+  // on that subject.
+  if (!!address.subject && this.policy.defaultSubjects) {
+    var filterSymbol = (address.subject.indexOf('*') || address.subject.indexOf('#')) ?
+      'apache.org:legacy-amqp-topic-binding:string' :
+      'apache.org:legacy-amqp-direct-binding:string';
+
+    linkPolicy.options.source.filter = AMQPClient.adapters.Translator([
+      'described', ['symbol', filterSymbol], ['string', address.subject]
+    ]);
   }
 
   var self = this;

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -192,7 +192,7 @@ AMQPClient.prototype.createSender = function(address, options) {
     throw new Error('Must connect before creating links');
   }
 
-  address = u.parseLinkAddress(address || this._defaultQueue);
+  address = u.parseLinkAddress(address || this._defaultQueue, this.policy);
   options = options || {};
 
   var linkName = u.linkName(address.name, options),
@@ -245,7 +245,7 @@ AMQPClient.prototype.createReceiver = function(address, options) {
     throw new Error('Must connect before creating links');
   }
 
-  address = u.parseLinkAddress(address || this._defaultQueue);
+  address = u.parseLinkAddress(address || this._defaultQueue, this.policy);
   options = options || {};
 
   var linkName = u.linkName(address.name, options),

--- a/lib/policies/default_policy.js
+++ b/lib/policies/default_policy.js
@@ -19,10 +19,20 @@ function linkName(prefix) {
 
 
 /**
- * Policies encode many of the optional behaviors and settings of AMQP into a cohesive place,
- * that could potentially be standardized, could be loaded from JSON, etc.
+ * Policies encode many of the optional behaviors and settings of AMQP into a
+ * cohesive place that could potentially be standardized, could be loaded from
+ * JSON, etc.
  */
 module.exports = {
+  // support subjects in link names with the following characteristics:
+  // receiver: "amq.topic/news", means a filter on the ReceiverLink will be made
+  //           for messages send with a subject "news"
+  //
+  // sender: "amq.topic/news", will automatically set "news" as the subject for
+  //         messages sent on this link, unless the user explicitly overrides
+  //         the subject.
+  defaultSubjects: true,
+
   reconnect: {
     retries: 10,
     strategy: 'fibonacci', // || 'exponential'

--- a/lib/policies/event_hub_policy.js
+++ b/lib/policies/event_hub_policy.js
@@ -3,6 +3,4 @@
 var u = require('../utilities'),
     ServiceBusPolicy = require('./service_bus_policy');
 
-module.exports = u.deepMerge({
-}, ServiceBusPolicy);
-
+module.exports = u.deepMerge({}, ServiceBusPolicy);

--- a/lib/policies/service_bus_policy.js
+++ b/lib/policies/service_bus_policy.js
@@ -5,6 +5,7 @@ var constants = require('../constants'),
     DefaultPolicy = require('./default_policy');
 
 module.exports = u.deepMerge({
+  defaultSubjects: false,
   senderLink: {
     options: {
       role: constants.linkRole.sender,

--- a/lib/policies/service_bus_queue_policy.js
+++ b/lib/policies/service_bus_queue_policy.js
@@ -3,6 +3,4 @@
 var u = require('../utilities'),
     ServiceBusPolicy = require('./service_bus_policy');
 
-module.exports = u.deepMerge({
-}, ServiceBusPolicy);
-
+module.exports = u.deepMerge({}, ServiceBusPolicy);

--- a/lib/policies/service_bus_topic_policy.js
+++ b/lib/policies/service_bus_topic_policy.js
@@ -3,6 +3,4 @@
 var u = require('../utilities'),
     ServiceBusPolicy = require('./service_bus_policy');
 
-module.exports = u.deepMerge({
-}, ServiceBusPolicy);
-
+module.exports = u.deepMerge({}, ServiceBusPolicy);

--- a/lib/sender_link.js
+++ b/lib/sender_link.js
@@ -62,6 +62,13 @@ SenderLink.prototype.send = function(msg, options) {
     throw new Error('Must connect before sending');
   }
 
+  options = options || {};
+  if (!!this.policy.defaultSubject) {
+    if (!options.properties) options.properties = {};
+    if (!options.properties.subject)
+      options.properties.subject = this.defaultSubject;
+  }
+
   var self = this;
   return new Promise(function(resolve, reject) {
     var message = new M.Message(options, self.policy.encoder(msg));

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -148,7 +148,11 @@ function parseAddress(address) {
 module.exports.parseAddress = parseAddress;
 
 // @todo: this "parsing" should be far more rigorous
-module.exports.parseLinkAddress = function(address) {
+module.exports.parseLinkAddress = function(address, policy) {
+  if (policy && !policy.defaultSubjects) {
+    return { name: address };
+  }
+
   var parts = address.split('/');
   var result = { name: parts.shift() };
   if (parts.length) result.subject = parts.shift();

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -147,6 +147,14 @@ function parseAddress(address) {
 
 module.exports.parseAddress = parseAddress;
 
+// @todo: this "parsing" should be far more rigorous
+module.exports.parseLinkAddress = function(address) {
+  var parts = address.split('/');
+  var result = { name: parts.shift() };
+  if (parts.length) result.subject = parts.shift();
+  return result;
+};
+
 function deepMerge() {
   var args = Array.prototype.slice.call(arguments);
   var helper = function(tgt, src, key) {

--- a/test/integration/qpid/receiver_link.test.js
+++ b/test/integration/qpid/receiver_link.test.js
@@ -1,0 +1,46 @@
+'use strict';
+var AMQPClient = require('../../..').Client,
+    c = require('../../../').Constants,
+    Promise = require('bluebird'),
+    config = require('./config'),
+    expect = require('chai').expect;
+
+var test = {};
+describe('QPID', function() {
+
+describe('ReceiverLink', function() {
+  beforeEach(function() {
+    if (!!test.client) test.client = undefined;
+    test.client = new AMQPClient();
+  });
+
+  afterEach(function() {
+    return test.client.disconnect().then(function() {
+      test.client = undefined;
+    });
+  });
+
+  it('should allow the definition of a default subject', function(done) {
+    return test.client.connect(config.address)
+      .then(function() {
+        return Promise.all([
+          test.client.createReceiver('amq.topic/not-news'),
+          test.client.createReceiver('amq.topic/news'),
+          test.client.createSender('amq.topic/news')
+        ]);
+      })
+      .spread(function(receiverWithoutSubject, receiverWithSubject, sender) {
+        receiverWithoutSubject.on('message', function(message) {
+          expect(message).to.not.exist;
+        });
+
+        receiverWithSubject.on('message', function(message) {
+          done();
+        });
+
+        return sender.send('test message', { properties: { subject: 'news' } });
+      });
+  });
+
+});
+});

--- a/test/unit/test_utilities.js
+++ b/test/unit/test_utilities.js
@@ -224,6 +224,26 @@ describe('Utilities', function() {
 
   });
 
+  describe('#parseLinkAddress', function() {
+    [
+      {
+        description: 'a simple link name',
+        address: 'amq.topic',
+        expected: { name: 'amq.topic' }
+      },
+      {
+        description: 'link name with subject',
+        address: 'amq.topic/news',
+        expected: { name: 'amq.topic', subject: 'news' }
+      }
+    ].forEach(function(testCase) {
+      it('should match ' + testCase.description, function() {
+        var result = u.parseLinkAddress(testCase.address);
+        expect(result).to.eql(testCase.expected);
+      });
+    });
+  });
+
   describe('#generateTimeouts', function() {
     it('should generate a fibonacci sequence of timeouts', function() {
       var options = {


### PR DESCRIPTION
This patch adds support for defining a subject in the name of a link during link creation. On the receiver side this adds a filter for the subject, and on the sender side this adds a default subject to the message properties (if one does not currently exist).