### PR TITLE
refactor(checkCredit): check credits only on disposition

### DIFF
--- a/lib/receiver_link.js
+++ b/lib/receiver_link.js
@@ -51,6 +51,8 @@ ReceiverLink.prototype.accept = function(message) {
     settled: true,
     state: new DeliveryState.Accepted()
   }));
+
+  this._checkCredit();
 };
 
 ReceiverLink.prototype.reject = function(message, reason) {
@@ -59,6 +61,8 @@ ReceiverLink.prototype.reject = function(message, reason) {
     settled: true,
     state: new DeliveryState.Rejected({ error: reason })
   }));
+
+  this._checkCredit();
 };
 
 // private API
@@ -115,7 +119,6 @@ ReceiverLink.prototype._messageReceived = function(transferFrame) {
   debug('received from (' + this.name + '): ' + message.body);
 
   this.emit(Link.MessageReceived, message);
-  this._checkCredit();
 };
 
 ReceiverLink.prototype._dispositionReceived = function(details) {


### PR DESCRIPTION
_checkCredit was previous called any time an incoming message was
received, however this doesn't necessarily jive with users trying
to maintain granular control over the flow of incoming messages.
Now, _checkCredits is only called on disposition.