### PR TITLE
Keep session links

### DIFF
--- a/examples/servicebus_reconnect.js
+++ b/examples/servicebus_reconnect.js
@@ -17,44 +17,65 @@ function argCheck(settings, options) {
 
 if (process.argv.length < 3) {
   console.warn('Usage: node ' + process.argv[1] + ' <settings json file>');
-} else {
-  var settingsFile = process.argv[2];
-  var settings = require('./' + settingsFile);
-  argCheck(settings, ['serviceBusHost', 'SASKeyName', 'SASKey', 'queueName']);
-  var protocol = settings.protocol || 'amqps';
-  var serviceBusHost = settings.serviceBusHost + '.servicebus.windows.net';
-  if (settings.serviceBusHost.indexOf(".") !== -1) {
-    serviceBusHost = settings.serviceBusHost;
-  }
-  var sasName = settings.SASKeyName;
-  var sasKey = settings.SASKey;
-  var queueName = settings.queueName;
-
-  var uri = protocol + '://' + encodeURIComponent(sasName) + ':' + encodeURIComponent(sasKey) + '@' + serviceBusHost;
-
-  var msgVal = 1;
-  var delayBetweenSending = 1000 * 60;
-  var iteration = 0;
-  var numIters = 1;
-  var client = new AMQPClient(Policy.ServiceBusQueue);
-  client.connect(uri).then(function () {
-    client.createSender(queueName).then(function (sender) {
-      setInterval(function () {
-        iteration++;
-        if (iteration === numIters) {
-          numIters *= 2;
-          iteration = 0;
-          console.log('===> Sending message ' + msgVal + ', ' + numIters + ' mins to next send.');
-          sender.send({"DataString": "From Node", "DataValue": msgVal++}).then(function (state) {
-            console.log('State: ', state);
-          }).catch(function (eSend) {
-            console.warn('Failed to send: ' + eSend);
-          });
-        }
-      }, delayBetweenSending);
-    });
-  }).catch(function (e) {
-    console.warn('Error send/receive: ' + e);
-  });
+  process.exit(1);
 }
+
+var settingsFile = process.argv[2];
+var settings = require('./' + settingsFile);
+argCheck(settings, ['serviceBusHost', 'SASKeyName', 'SASKey', 'queueName']);
+var protocol = settings.protocol || 'amqps';
+var serviceBusHost = settings.serviceBusHost + '.servicebus.windows.net';
+if (settings.serviceBusHost.indexOf(".") !== -1) {
+  serviceBusHost = settings.serviceBusHost;
+}
+var sasName = settings.SASKeyName;
+var sasKey = settings.SASKey;
+var queueName = settings.queueName;
+
+var uri = protocol + '://' + encodeURIComponent(sasName) + ':' + encodeURIComponent(sasKey) + '@' + serviceBusHost;
+
+var msgVal = 1;
+var delayBetweenSending = 1000 * 60;
+var iteration = 0;
+var numIters = 16;
+var client = new AMQPClient(Policy.ServiceBusQueue);
+client.connect(uri).then(function () {
+  client.on('client:errorReceived', function (err) {
+    console.warn('===> CLIENT ERROR: ', err);
+  });
+  client.on('connection:closed', function() {
+    console.warn('===> CONNECTION CLOSED');
+  });
+  return client.createSender(queueName);
+}).then(function (sender) {
+  sender.on('errorReceived', function(tx_err) {
+    console.warn('===> TX ERROR: ', tx_err);
+  });
+  sender.on('detached', function() {
+    console.warn('===> TX DETACHED');
+  });
+  sender.session.on('unmapped', function() {
+    console.warn('===> SESSION UNMAPPED');
+  });
+  sender.session.on('errorReceived', function(err) {
+    console.warn('===> SESSION ERROR: ', err);
+  });
+  setInterval(function () {
+    iteration++;
+    if (iteration === numIters) {
+      numIters /= 2;
+      iteration = 0;
+      console.log('===> SENDING message ' + msgVal + ', ' + numIters + ' mins to next send. Link state: ' + sender.state());
+      sender.send({"DataString": "From Node", "DataValue": msgVal++}).then(function (state) {
+        console.log('State: ', state);
+      }).catch(function (eSend) {
+        console.warn('===> TX SEND FAILURE: ', eSend);
+      });
+    } else {
+      console.log('===> ' + (numIters - iteration) + ' minutes until sending. Link state: ' + sender.state());
+    }
+  }, delayBetweenSending);
+}).catch(function (e) {
+  console.warn('===> CONNECT ERROR: ', e);
+});
 

--- a/examples/servicebus_reconnect.js
+++ b/examples/servicebus_reconnect.js
@@ -82,6 +82,8 @@ function sendReceiveAndQuit(policy, minutesUntilSend) {
           remaining--;
           if (remaining === 0) {
             clearInterval(interval);
+            // Note that if you create the receiver at the same time as the sender,
+            //  it doesn't seem to trigger the behavior (i.e. an active receiver link stops the auto-detach).
             client.createReceiver(queueName).then(function (receiver) {
               receiver.on('errorReceived', function (rx_err) {
                 console.warn('===> RX ERROR: ', rx_err);

--- a/examples/servicebus_reconnect.js
+++ b/examples/servicebus_reconnect.js
@@ -1,8 +1,19 @@
+///
+/// A simple example showing ServiceBus' disconnect behavior:
+/// - It seems to drop unused send links at around 10 minutes, despite heartbeat frames.
+/// - It then drops the connection entirely at around 20 minutes.
+///
+/// The Link has logic to deal with re-attaching for this detach at 10 minutes, and
+///  the connection has logic to deal with re-connecting and re-establishing links.
+///
+/// The code below demonstrates both.
+///
 
 'use strict';
 //var AMQPClient = require('amqp10').Client;
 var AMQPClient  = require('../lib').Client,
-  Policy = require('../lib').Policy;
+  Policy = require('../lib').Policy,
+  Promise = require('bluebird');
 
 // Simple argument-checker, you can ignore.
 function argCheck(settings, options) {
@@ -34,48 +45,80 @@ var queueName = settings.queueName;
 
 var uri = protocol + '://' + encodeURIComponent(sasName) + ':' + encodeURIComponent(sasKey) + '@' + serviceBusHost;
 
-var msgVal = 1;
-var delayBetweenSending = 1000 * 60;
-var iteration = 0;
-var numIters = 16;
-var client = new AMQPClient(Policy.ServiceBusQueue);
-client.connect(uri).then(function () {
-  client.on('client:errorReceived', function (err) {
-    console.warn('===> CLIENT ERROR: ', err);
+function sendReceiveAndQuit(policy, minutesUntilSend) {
+  var msgVal = Math.floor(Math.random() * 1000000);
+  var min = 60 * 1000;
+  var remaining = minutesUntilSend;
+  return new Promise(function (resolve, reject) {
+    var client = new AMQPClient(policy);
+    client.on('client:errorReceived', function (err) {
+      console.warn('===> CLIENT ERROR: ', err);
+    });
+    client.on('connection:closed', function() {
+      console.warn('===> CONNECTION CLOSED');
+    });
+    client.connect(uri).then(function() {
+      return client.createSender(queueName);
+    })
+      .then(function (sender) {
+        sender.on('errorReceived', function(tx_err) {
+          console.warn('===> TX ERROR: ', tx_err);
+        });
+        sender.on('detached', function() {
+          console.warn('===> TX DETACHED');
+        });
+        sender.session.on('unmapped', function() {
+          console.warn('===> SESSION UNMAPPED');
+        });
+        sender.session.on('errorReceived', function(err) {
+          console.warn('===> SESSION ERROR: ', err);
+        });
+        setTimeout(function() {
+          client.disconnect().then(function() {
+            reject('Message not seen in ' + (minutesUntilSend + 1) + ' minutes');
+          });
+        }, (minutesUntilSend + 1) * min);
+        var interval = setInterval(function() {
+          remaining--;
+          if (remaining === 0) {
+            clearInterval(interval);
+            client.createReceiver(queueName).then(function (receiver) {
+              receiver.on('errorReceived', function (rx_err) {
+                console.warn('===> RX ERROR: ', rx_err);
+              });
+              receiver.on('detached', function () {
+                console.warn('===> RX DETACHED');
+              });
+              receiver.on('message', function (msg) {
+                if (msg.body && msg.body.DataValue && msg.body.DataValue === msgVal) {
+                  client.disconnect().then(function () {
+                    console.log("\n=================\nExpected Value Seen\n==================\n");
+                    resolve();
+                  });
+                }
+              });
+              sender.send({"DataString": "From Node", "DataValue": msgVal}).then(function (state) {
+                console.log('State: ', state);
+              }).catch(function (eSend) {
+                console.warn('===> TX SEND FAILURE: ', eSend);
+              });
+            });
+          } else {
+            console.log('===> ' + remaining + ' minutes remaining until sending.');
+          }
+        }, min);
+      })
   });
-  client.on('connection:closed', function() {
-    console.warn('===> CONNECTION CLOSED');
+}
+
+var noReattach = Policy.merge({ senderLink: { reattach: null }, receiverLink: { reattach: null } }, Policy.ServiceBusQueue);
+var reattach = Policy.ServiceBusQueue;
+
+var minutesUntilServiceBusDropsLink = 10;
+var minutesUntilServiceBusDropsConnection = 20;
+sendReceiveAndQuit(reattach, minutesUntilServiceBusDropsLink+ 1).then(function() {
+  sendReceiveAndQuit(noReattach, minutesUntilServiceBusDropsConnection + 1).then(function() {
+    console.log("\n==================\nComplete\n==================");
   });
-  return client.createSender(queueName);
-}).then(function (sender) {
-  sender.on('errorReceived', function(tx_err) {
-    console.warn('===> TX ERROR: ', tx_err);
-  });
-  sender.on('detached', function() {
-    console.warn('===> TX DETACHED');
-  });
-  sender.session.on('unmapped', function() {
-    console.warn('===> SESSION UNMAPPED');
-  });
-  sender.session.on('errorReceived', function(err) {
-    console.warn('===> SESSION ERROR: ', err);
-  });
-  setInterval(function () {
-    iteration++;
-    if (iteration === numIters) {
-      numIters /= 2;
-      iteration = 0;
-      console.log('===> SENDING message ' + msgVal + ', ' + numIters + ' mins to next send. Link state: ' + sender.state());
-      sender.send({"DataString": "From Node", "DataValue": msgVal++}).then(function (state) {
-        console.log('State: ', state);
-      }).catch(function (eSend) {
-        console.warn('===> TX SEND FAILURE: ', eSend);
-      });
-    } else {
-      console.log('===> ' + (numIters - iteration) + ' minutes until sending. Link state: ' + sender.state());
-    }
-  }, delayBetweenSending);
-}).catch(function (e) {
-  console.warn('===> CONNECT ERROR: ', e);
 });
 

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -74,7 +74,6 @@ function AMQPClient(policy) {
   this._connection = null;
   this._session = null;
 
-  this._reattach = {};
   this._reconnect = null;
   if (!!this.policy.reconnect) {
     this._timeouts = u.generateTimeouts(this.policy.reconnect);
@@ -224,7 +223,6 @@ AMQPClient.prototype.createSender = function(address, options) {
       link._onAttach.push(attachPromise);
     };
 
-    self._reattach[linkName] = attach;
     attach();
   });
 };
@@ -297,7 +295,6 @@ AMQPClient.prototype.createReceiver = function(address, options) {
       link._onAttach.push(attachPromise);
     };
 
-    self._reattach[linkName] = attach;
     attach();
   });
 };
@@ -329,13 +326,11 @@ AMQPClient.prototype.disconnect = function() {
 
 AMQPClient.prototype._clearConnectionState = function(saveReconnectDetails) {
   this._connection = null;
-  //this._session = null;
 
   // Copy from original to avoid any settings changes "sticking" across connections.
   this.policy = u.deepMerge(this._originalPolicy);
 
   if (!saveReconnectDetails) {
-    this._reattach = {};
     this._reconnect = null;
   }
 };
@@ -350,7 +345,6 @@ AMQPClient.prototype._newSession = function(conn) {
 };
 
 AMQPClient.prototype._preventReconnect = function() {
-  this._reattach = {};
   this._reconnect = null;
 };
 

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -133,19 +133,24 @@ AMQPClient.prototype.connect = function(url) {
     self._connection.on(Connection.Connected, function(c) {
       debug('connected');
       self.emit(AMQPClient.ConnectionOpened);
-      self._session = self._newSession(c);
+      if (self._session) {
+        debug('session already exists, re-using');
+        self._session.connection = self._connection;
+      } else {
+        self._session = self._newSession(c);
+        self._session.on(Session.Unmapped, function(s) {
+          debug('unmapped');
+        });
+
+        self._session.on(Session.ErrorReceived, function(e) {
+          debug('session error: ', e);
+          self.emit(AMQPClient.ErrorReceived, e);
+        });
+      }
+
       self._session.on(Session.Mapped, function(s) {
         debug('mapped');
         resolve(self);
-      });
-
-      self._session.on(Session.Unmapped, function(s) {
-        debug('unmapped');
-      });
-
-      self._session.on(Session.ErrorReceived, function(e) {
-        debug('session error: ', e);
-        self.emit(AMQPClient.ErrorReceived, e);
       });
 
       self._session.begin(self.policy.session);
@@ -159,8 +164,7 @@ AMQPClient.prototype.connect = function(url) {
         return reject(new errors.DisconnectedError());
       }
 
-      if (!self._timeouts.length)
-        self._timeouts = u.generateTimeouts(self.policy.reconnect);
+      if (!self._timeouts.length) self._timeouts = u.generateTimeouts(self.policy.reconnect);
 
       setTimeout(function() {
         // @todo: see _attemptReconnection below for more detail, but bail here
@@ -325,7 +329,7 @@ AMQPClient.prototype.disconnect = function() {
 
 AMQPClient.prototype._clearConnectionState = function(saveReconnectDetails) {
   this._connection = null;
-  this._session = null;
+  //this._session = null;
 
   // Copy from original to avoid any settings changes "sticking" across connections.
   this.policy = u.deepMerge(this._originalPolicy);

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -365,13 +365,6 @@ AMQPClient.prototype._attemptReconnection = function() {
 
   var self = this;
   return self._reconnect()
-    .then(function() {
-      debug('reconnected and remapped, attempting to re-attach links');
-      Object.keys(self._reattach).forEach(function(link) {
-        debug('reattaching link: ' + link);
-        self._reattach[link]();
-      });
-    })
     .catch(function(err) {
       self.emit(AMQPClient.ErrorReceived, err);
 

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -137,14 +137,6 @@ AMQPClient.prototype.connect = function(url) {
         self._session.connection = self._connection;
       } else {
         self._session = self._newSession(c);
-        self._session.on(Session.Unmapped, function(s) {
-          debug('unmapped');
-        });
-
-        self._session.on(Session.ErrorReceived, function(e) {
-          debug('session error: ', e);
-          self.emit(AMQPClient.ErrorReceived, e);
-        });
       }
 
       self._session.on(Session.Mapped, function(s) {
@@ -170,11 +162,6 @@ AMQPClient.prototype.connect = function(url) {
         //        using .done() for now
         return self._attemptReconnection().done();
       }, self._timeouts.shift());
-    });
-
-    self._connection.on(Connection.ErrorReceived, function(e) {
-      debug('connection error: ', e);
-      self.emit(AMQPClient.ErrorReceived, e);
     });
 
     self._connection.open(address, sasl);
@@ -337,11 +324,29 @@ AMQPClient.prototype._clearConnectionState = function(saveReconnectDetails) {
 
 // Helper methods for mocking in tests.
 AMQPClient.prototype._newConnection = function() {
-  return new Connection(this.policy.connect);
+  var self = this;
+  var connection = new Connection(this.policy.connect);
+  connection.on(Connection.ErrorReceived, function(e) {
+    debug('connection error: ', e);
+    self.emit(AMQPClient.ErrorReceived, e);
+  });
+
+  return connection;
 };
 
 AMQPClient.prototype._newSession = function(conn) {
-  return new Session(conn);
+  var self = this;
+  var session = new Session(conn);
+  session.on(Session.Unmapped, function(s) {
+    debug('unmapped');
+  });
+
+  session.on(Session.ErrorReceived, function(e) {
+    debug('session error: ', e);
+    self.emit(AMQPClient.ErrorReceived, e);
+  });
+
+  return session;
 };
 
 AMQPClient.prototype._preventReconnect = function() {

--- a/lib/link.js
+++ b/lib/link.js
@@ -22,6 +22,9 @@ function Link(session, handle, linkPolicy) {
   this.remoteHandle = undefined;
 
   this._onAttach = [];
+  if (!!this.policy.reattach) {
+    this._timeouts = u.generateTimeouts(this.policy.reattach);
+  }
 
   var self = this;
   var stateMachine = {
@@ -42,6 +45,9 @@ function Link(session, handle, linkPolicy) {
       detachReceived: function() {
         self._sendDetach();
         return this.DETACHING;
+      },
+      forceDetach: function() {
+        return this.DETACHED;
       }
     },
     'DETACHING': {
@@ -55,7 +61,7 @@ function Link(session, handle, linkPolicy) {
   };
 
   this.linkSM = new StateMachine(stateMachine).bind(function(event, oldState, newState) {
-    debug('Transitioning from ' + oldState + ' to ' + newState + ' due to ' + event);
+    debug(self.name + ':' + self.handle + ': Transitioning from ' + oldState + ' to ' + newState + ' due to ' + event);
   });
 }
 
@@ -116,6 +122,15 @@ Link.prototype.detach = function() {
   return detachPromise;
 };
 
+///
+/// Force link state to detached without sending detach message - usually due to forcible disconnect or unmap from above.
+/// Important bit is that this should not trigger auto-reattach behavior as that'll happen with reconnect.
+///
+Link.prototype.forceDetach = function() {
+  debug('Force-detach for ' + this.name + '. Current state: ' + this.state());
+  this.linkSM.forceDetach();
+};
+
 // private api
 Link.prototype._resolveAttachPromises = function(err, link) {
   while (this._onAttach.length) {
@@ -130,7 +145,7 @@ Link.prototype._attachReceived = function(attachFrame) {
   // process params.
   this.remoteHandle = attachFrame.handle;
   this.session._linksByRemoteHandle[this.remoteHandle] = this;
-  debug('attached CH=[' + this.session.channel + '=>' + attachFrame.channel + '], Handle=[' + this.handle + '=>' + attachFrame.handle + ']');
+  debug(this.name + ': attached CH=[' + this.session.channel + '=>' + attachFrame.channel + '], Handle=[' + this.handle + '=>' + attachFrame.handle + ']');
 
   this.emit(Link.Attached, this);
   this._resolveAttachPromises(null, this);
@@ -168,6 +183,28 @@ Link.prototype._detached = function(frame) {
 
   this.emit(Link.Detached, { closed: frame.closed, error: frame.error });
   this._resolveAttachPromises(frame.error ? frame.error : 'link closed');
+
+  var self = this;
+  if (!self._shouldReattach()) return;
+
+  if (!self._timeouts.length) self._timeouts = u.generateTimeouts(self.policy.reattach);
+
+  setTimeout(function() {
+    // @todo: see _attemptReattach below for more detail, but bail here
+    //        using .done() for now
+    self._attemptReattach();
+  }, self._timeouts.shift());
+};
+
+Link.prototype._shouldReattach = function() {
+  if (!this.session || !this._reattach) return false;
+  if (!this._timeouts.length && !this.policy.reconnect.forever) return false;
+  return true;
+};
+
+Link.prototype._attemptReattach = function() {
+  debug('Attempting to reattach ' + this.name);
+  this.attach();
 };
 
 module.exports = Link;

--- a/lib/link.js
+++ b/lib/link.js
@@ -23,7 +23,7 @@ function Link(session, handle, linkPolicy) {
   this.remoteHandle = undefined;
 
   this._onAttach = [];
-  if (!!this.policy.reattach) {
+  if (this.policy && this.policy.reattach) {
     this._timeouts = u.generateTimeouts(this.policy.reattach);
   }
 

--- a/lib/link.js
+++ b/lib/link.js
@@ -9,6 +9,7 @@ var _ = require('lodash'),
 
     debug = require('debug')('amqp10:link'),
     constants = require('./constants'),
+    u = require('./utilities'),
 
     AttachFrame = require('./frames/attach_frame'),
     DetachFrame = require('./frames/detach_frame'),
@@ -106,11 +107,13 @@ Link.prototype.attach = function() {
 
 Link.prototype.detach = function() {
   var self = this;
+  this._timeouts = undefined; // Disable any re-attachment policy.
   var detachPromise = new Promise(function(resolve, reject) {
     var onError = function(err) { reject(err); };
     self.once(Link.ErrorReceived, onError);
     self.once(Link.Detached, function(info) {
       self.removeListener(Link.ErrorReceived, onError);
+      self.session._removeLink(self);
       if (!!info.error) return reject(info.error);
       if (!info.closed) return reject('link not closed');
       resolve();
@@ -197,7 +200,7 @@ Link.prototype._detached = function(frame) {
 };
 
 Link.prototype._shouldReattach = function() {
-  if (!this.session || !this._reattach) return false;
+  if (!this.session || !this._timeouts) return false;
   if (!this._timeouts.length && !this.policy.reconnect.forever) return false;
   return true;
 };

--- a/lib/link.js
+++ b/lib/link.js
@@ -190,8 +190,6 @@ Link.prototype._detached = function(frame) {
   if (!self._timeouts.length) self._timeouts = u.generateTimeouts(self.policy.reattach);
 
   setTimeout(function() {
-    // @todo: see _attemptReattach below for more detail, but bail here
-    //        using .done() for now
     self._attemptReattach();
   }, self._timeouts.shift());
 };

--- a/lib/link.js
+++ b/lib/link.js
@@ -182,8 +182,6 @@ Link.prototype._detached = function(frame) {
     this.remoteHandle = undefined;
   }
 
-  delete this.session._allocatedHandles[this.policy.options.handle];
-
   this.emit(Link.Detached, { closed: frame.closed, error: frame.error });
   this._resolveAttachPromises(frame.error ? frame.error : 'link closed');
 
@@ -201,7 +199,7 @@ Link.prototype._detached = function(frame) {
 
 Link.prototype._shouldReattach = function() {
   if (!this.session || !this._timeouts) return false;
-  if (!this._timeouts.length && !this.policy.reconnect.forever) return false;
+  if (!this._timeouts.length && !this.policy.reattach.forever) return false;
   return true;
 };
 

--- a/lib/link.js
+++ b/lib/link.js
@@ -113,7 +113,6 @@ Link.prototype.detach = function() {
     self.once(Link.ErrorReceived, onError);
     self.once(Link.Detached, function(info) {
       self.removeListener(Link.ErrorReceived, onError);
-      self.session._removeLink(self);
       if (!!info.error) return reject(info.error);
       if (!info.closed) return reject('link not closed');
       resolve();
@@ -186,7 +185,7 @@ Link.prototype._detached = function(frame) {
   this._resolveAttachPromises(frame.error ? frame.error : 'link closed');
 
   var self = this;
-  if (!self._shouldReattach()) return;
+  if (!self.shouldReattach()) return;
 
   if (!self._timeouts.length) self._timeouts = u.generateTimeouts(self.policy.reattach);
 
@@ -197,7 +196,7 @@ Link.prototype._detached = function(frame) {
   }, self._timeouts.shift());
 };
 
-Link.prototype._shouldReattach = function() {
+Link.prototype.shouldReattach = function() {
   if (!this.session || !this._timeouts) return false;
   if (!this._timeouts.length && !this.policy.reattach.forever) return false;
   return true;

--- a/lib/policies/default_policy.js
+++ b/lib/policies/default_policy.js
@@ -77,7 +77,8 @@ module.exports = {
       initialDeliveryCount: 1
     },
     callback: putils.SenderCallbackPolicies.OnSettle,
-    encoder: function(body) { return body; }
+    encoder: function(body) { return body; },
+    reattach: null
   },
   receiverLink: {
     options: {
@@ -88,6 +89,7 @@ module.exports = {
     },
     credit: putils.CreditPolicies.RefreshAtHalf,
     creditQuantum: 100,
-    decoder: function(body) { return body; }
+    decoder: function(body) { return body; },
+    reattach: null
   }
 };

--- a/lib/policies/service_bus_policy.js
+++ b/lib/policies/service_bus_policy.js
@@ -20,6 +20,11 @@ module.exports = u.deepMerge({
         bodyStr = JSON.stringify(body);
       }
       return new Buffer(bodyStr, 'utf8');
+    },
+    reattach: {
+      retries: 10,
+      strategy: 'fibonacci', // || 'exponential'
+      forever: true
     }
   },
   receiverLink: {
@@ -44,6 +49,11 @@ module.exports = u.deepMerge({
       } catch (e) {
         return bodyStr;
       }
+    },
+    reattach: {
+      retries: 10,
+      strategy: 'fibonacci', // || 'exponential'
+      forever: true
     }
   }
 }, DefaultPolicy);

--- a/lib/session.js
+++ b/lib/session.js
@@ -239,6 +239,7 @@ Session.prototype.createLink = function(linkPolicy) {
 /// Remove a link from the sender
 ///
 Session.prototype._removeLink = function(link) {
+  delete this._allocatedHandles[link.policy.options.handle];
   if (link instanceof SenderLink) {
     debug('Removing sender link ' + link.name);
     delete self._senderLinks[link.name];

--- a/lib/session.js
+++ b/lib/session.js
@@ -221,6 +221,7 @@ Session.prototype.createLink = function(linkPolicy) {
   var self = this;
   link.on(Link.Detached, function(details) {
     debug('detached(' + link.name + '): ' + (details ? details.error : 'No details'));
+    if (!link.shouldReattach()) self._removeLink(self);
   });
 
   link.on(Link.ErrorReceived, function(err) {

--- a/lib/session.js
+++ b/lib/session.js
@@ -242,10 +242,10 @@ Session.prototype._removeLink = function(link) {
   delete this._allocatedHandles[link.policy.options.handle];
   if (link instanceof SenderLink) {
     debug('Removing sender link ' + link.name);
-    delete self._senderLinks[link.name];
+    delete this._senderLinks[link.name];
   } else {
     debug('Removing receiver link ' + link.name);
-    delete self._receiverLinks[link.name];
+    delete this._receiverLinks[link.name];
   }
 };
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -364,6 +364,7 @@ Session.prototype._beginReceived = function(frame) {
 
   // attach all links
   var attachHandler = function(l) {
+    debug('Attaching link ' + l.name + ':' + l.handle + ' after begin received');
     if (l.state() !== 'attached' && l.state() !== 'attaching') l.attach();
   };
   _.values(this._senderLinks).forEach(attachHandler);
@@ -420,6 +421,14 @@ Session.prototype._unmap = function() {
     this.channel = undefined;
     this.mapped = false;
     this.emit(Session.Unmapped);
+
+    debug('Session unmapped - force-detaching all links.');
+    // force-detach all links (they've already been detached due to unmap, just need to let them know about it)
+    var detachHandler = function(l) {
+      if (l.state() === 'attached') l.forceDetach();
+    };
+    _.values(this._senderLinks).forEach(detachHandler);
+    _.values(this._receiverLinks).forEach(detachHandler);
   }
 };
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -221,11 +221,6 @@ Session.prototype.createLink = function(linkPolicy) {
   var self = this;
   link.on(Link.Detached, function(details) {
     debug('detached(' + link.name + '): ' + (details ? details.error : 'No details'));
-    if (policy.options.role === constants.linkRole.sender) {
-      delete self._senderLinks[policy.options.name];
-    } else {
-      delete self._receiverLinks[policy.options.name];
-    }
   });
 
   link.on(Link.ErrorReceived, function(err) {
@@ -238,6 +233,19 @@ Session.prototype.createLink = function(linkPolicy) {
   }
 
   return link;
+};
+
+///
+/// Remove a link from the sender
+///
+Session.prototype._removeLink = function(link) {
+  if (link instanceof SenderLink) {
+    debug('Removing sender link ' + link.name);
+    delete self._senderLinks[link.name];
+  } else {
+    debug('Removing receiver link ' + link.name);
+    delete self._receiverLinks[link.name];
+  }
 };
 
 Session.prototype.addWindow = function(windowSize, flowOptions) {
@@ -420,7 +428,6 @@ Session.prototype._unmap = function() {
     this.remoteChannel = undefined;
     this.channel = undefined;
     this.mapped = false;
-    this.emit(Session.Unmapped);
 
     debug('Session unmapped - force-detaching all links.');
     // force-detach all links (they've already been detached due to unmap, just need to let them know about it)
@@ -429,6 +436,8 @@ Session.prototype._unmap = function() {
     };
     _.values(this._senderLinks).forEach(detachHandler);
     _.values(this._receiverLinks).forEach(detachHandler);
+
+    this.emit(Session.Unmapped);
   }
 };
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -197,6 +197,7 @@ function deepMerge() {
 }
 
 module.exports.deepMerge = deepMerge;
+module.exports.deepCopy = deepMerge;
 
 function coerce(val, T) {
   if (val === null || val === undefined) return null;

--- a/test/unit/test_amqpclient.js
+++ b/test/unit/test_amqpclient.js
@@ -130,6 +130,7 @@ describe('AMQPClient', function() {
           expect(l.messages[0].message).to.eql({my: 'message'});
         });
     });
+
   });
 
   describe('#receive()', function() {


### PR DESCRIPTION
I was closer to right than you were - it was more than just not setting session to null.

- Remove reattach logic from client
- Stop setting session to null on disconnect
- Stop session from clearing link state on detach
- Add reattach policies for link, akin to client's reconnect policies
- Ensure link doesn't attempt reattach if it's detached by our side
- Add a "forceDetach" to force existing links into a detached state if the session/connection is killed