### PR TITLE
feat(ReceiverLink): add Released and Modified outcomes

### DIFF
--- a/lib/receiver_link.js
+++ b/lib/receiver_link.js
@@ -51,13 +51,7 @@ ReceiverLink.prototype.addCredits = function(credits, flowOptions) {
  * @param {String|Array}  [message] message, or array of messages to settle
  */
 ReceiverLink.prototype.accept = function(message) {
-  var range = u.dispositionRange(message);
-  this._sendDisposition(_.defaults(range, {
-    settled: true,
-    state: new DeliveryState.Accepted()
-  }));
-
-  this._checkCredit();
+  this.settle(message, new DeliveryState.Accepted());
 };
 
 /**
@@ -67,13 +61,7 @@ ReceiverLink.prototype.accept = function(message) {
  * @param {String}        [error] error that caused the message to be rejected
  */
 ReceiverLink.prototype.reject = function(message, error) {
-  var range = u.dispositionRange(message);
-  this._sendDisposition(_.defaults(range, {
-    settled: true,
-    state: new DeliveryState.Rejected({ error: error })
-  }));
-
-  this._checkCredit();
+  this.settle(message, new DeliveryState.Rejected({ error: error }));
 };
 
 /**
@@ -82,13 +70,7 @@ ReceiverLink.prototype.reject = function(message, error) {
  * @param {String|Array}  [message] message, or array of messages to settle
  */
 ReceiverLink.prototype.release = function(message) {
-  var range = u.dispositionRange(message);
-  this._sendDisposition(_.defaults(range, {
-    settled: true,
-    state: new DeliveryState.Released()
-  }));
-
-  this._checkCredit();
+  this.settle(message, new DeliveryState.Released());
 };
 
 /**
@@ -101,15 +83,24 @@ ReceiverLink.prototype.release = function(message) {
  * @param {Object}        [options.messageAnnotations] message attributes to combine with existing annotations
  */
 ReceiverLink.prototype.modify = function(message, options) {
+  this.settle(message, new DeliveryState.Modified(options));
+};
+
+/**
+ * Settle a message (or array of messages) with a given delivery state
+ *
+ * @param {String|Array}  [message] message, or array of messages to settle
+ * @param {Object}        [state] outcome of message delivery
+ */
+ReceiverLink.prototype.settle = function(message, state) {
   var range = u.dispositionRange(message);
   this._sendDisposition(_.defaults(range, {
     settled: true,
-    state: new DeliveryState.Modified(options)
+    state: state
   }));
 
   this._checkCredit();
 };
-
 
 
 // private API

--- a/lib/receiver_link.js
+++ b/lib/receiver_link.js
@@ -45,6 +45,11 @@ ReceiverLink.prototype.addCredits = function(credits, flowOptions) {
   this.session.connection.sendFrame(new FlowFrame(options));
 };
 
+/**
+ * Settle a message (or array of messages) with an Accepted delivery outcome
+ *
+ * @param {String|Array}  [message] message, or array of messages to settle
+ */
 ReceiverLink.prototype.accept = function(message) {
   var range = u.dispositionRange(message);
   this._sendDisposition(_.defaults(range, {
@@ -55,15 +60,57 @@ ReceiverLink.prototype.accept = function(message) {
   this._checkCredit();
 };
 
-ReceiverLink.prototype.reject = function(message, reason) {
+/**
+ * Settle a message (or array of messages) with a Rejected delivery outcome
+ *
+ * @param {String|Array}  [message] message, or array of messages to settle
+ * @param {String}        [error] error that caused the message to be rejected
+ */
+ReceiverLink.prototype.reject = function(message, error) {
   var range = u.dispositionRange(message);
   this._sendDisposition(_.defaults(range, {
     settled: true,
-    state: new DeliveryState.Rejected({ error: reason })
+    state: new DeliveryState.Rejected({ error: error })
   }));
 
   this._checkCredit();
 };
+
+/**
+ * Settle a message (or array of messages) with a Released delivery outcome
+ *
+ * @param {String|Array}  [message] message, or array of messages to settle
+ */
+ReceiverLink.prototype.release = function(message) {
+  var range = u.dispositionRange(message);
+  this._sendDisposition(_.defaults(range, {
+    settled: true,
+    state: new DeliveryState.Released()
+  }));
+
+  this._checkCredit();
+};
+
+/**
+ * Settle a message (or array of messages) with a Modified delivery outcome
+ *
+ * @param {String|Array}  [message] message, or array of messages to settle
+ * @param {Object}        [options] options used for a Modified outcome
+ * @param {Boolean}       [options.deliveryFailed] count the transfer as an unsuccessful delivery attempt
+ * @param {Boolean}       [options.undeliverableHere] prevent redelivery
+ * @param {Object}        [options.messageAnnotations] message attributes to combine with existing annotations
+ */
+ReceiverLink.prototype.modify = function(message, options) {
+  var range = u.dispositionRange(message);
+  this._sendDisposition(_.defaults(range, {
+    settled: true,
+    state: new DeliveryState.Modified(options)
+  }));
+
+  this._checkCredit();
+};
+
+
 
 // private API
 ReceiverLink.prototype._attachReceived = function(attachFrame) {


### PR DESCRIPTION
  * Add two new disposition outcomes to ReceiverLink: Released and Modified
  * Share common code between all disposition methods, allowing a user to optionally directly use the   `settle` method as well
  * Documentation!