### PR TITLE
refactor(link-options): standardize link options for link creation

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -172,27 +172,27 @@ AMQPClient.prototype.connect = function(url) {
  * Creates a sender link for the given address, with optional link policy
  *
  * @method createSender
- * @param {String} [address]    An address to connect this link to
- * @param {Object} [options]    Policy used for creating the sender link
+ * @param {String} address              An address to connect this link to. If not provided will use default queue from connection uri.
+ * @param {Object} [policyOverrides]    Policy overrides used for creating this sender link
  *
  * @return {Promise}
  */
-AMQPClient.prototype.createSender = function(address, options) {
+AMQPClient.prototype.createSender = function(address, policyOverrides) {
   if (!this._connection) {
     throw new Error('Must connect before creating links');
   }
 
   address = u.parseLinkAddress(address || this._defaultQueue, this.policy);
-  options = options || {};
+  policyOverrides = policyOverrides || {};
 
-  var linkName = u.linkName(address.name, options),
+  var linkName = u.linkName(address.name, policyOverrides),
       linkPolicy = u.deepMerge({
         options: {
           name: linkName,
           source: { address: 'localhost' },
           target: { address: address.name }
         }
-      }, options, this.policy.senderLink);
+      }, policyOverrides, this.policy.senderLink);
 
   if (!!address.subject && this.policy.defaultSubjects) {
     linkPolicy.defaultSubject = address.subject;
@@ -220,27 +220,27 @@ AMQPClient.prototype.createSender = function(address, options) {
  * used to listen for 'message' events.
  *
  * @method createReceiver
- * @param {String} [source]     Source of the link to connect to.  If not provided will use default queue from connection uri.
- * @param {Object} [options]    Link policy used for creating this receiver link
+ * @param {String} address              An address to connect this link to.  If not provided will use default queue from connection uri.
+ * @param {Object} [policyOverrides]    Policy overrides used for creating this receiver link
  *
  * @return {Promise}
  */
-AMQPClient.prototype.createReceiver = function(address, options) {
+AMQPClient.prototype.createReceiver = function(address, policyOverrides) {
   if (!this._connection) {
     throw new Error('Must connect before creating links');
   }
 
   address = u.parseLinkAddress(address || this._defaultQueue, this.policy);
-  options = options || {};
+  policyOverrides = policyOverrides || {};
 
-  var linkName = u.linkName(address.name, options),
+  var linkName = u.linkName(address.name, policyOverrides),
       linkPolicy = u.deepMerge({
         options: {
           name: linkName,
           source: { address: address.name },
           target: { address: 'localhost' }
         }
-      }, options, this.policy.receiverLink);
+      }, policyOverrides, this.policy.receiverLink);
 
   // if a subject has been provided then automatically set up a filter to match
   // on that subject.

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -169,11 +169,11 @@ AMQPClient.prototype.connect = function(url) {
 };
 
 /**
- * Creates a sender link for the given address, with optional link options
+ * Creates a sender link for the given address, with optional link policy
  *
  * @method createSender
- * @param {string} [address]    An address to connect this link to
- * @param {*} [options]         Options used for creating the link
+ * @param {String} [address]    An address to connect this link to
+ * @param {Object} [options]    Policy used for creating the sender link
  *
  * @return {Promise}
  */
@@ -192,7 +192,7 @@ AMQPClient.prototype.createSender = function(address, options) {
           source: { address: 'localhost' },
           target: { address: address.name }
         }
-      }, this.policy.senderLink);
+      }, options, this.policy.senderLink);
 
   if (!!address.subject && this.policy.defaultSubjects) {
     linkPolicy.defaultSubject = address.subject;
@@ -215,17 +215,13 @@ AMQPClient.prototype.createSender = function(address, options) {
 };
 
 /**
- * Set up a callback to be called whenever message is received from the given source (subject to the given filter).
- * Callback is called with (error, message), and the payload is decoded using the receiver link policy's
- * decoder method. The method itself returns a promise which is resolved with receiver link information
- * once it's attached.
+ * Creates a receiver link for the given address, with optional link policy. The
+ * promise returned resolves to a link that is an EventEmitter, which can be
+ * used to listen for 'message' events.
  *
  * @method createReceiver
- * @param {string} [source]     Source of the link to connect to.  If not provided will use default queue from connection uri.
- * @param {Object} [options]    Options used for link creation
- * @param options.filter        Filter used in connecting to the source.  See AMQP spec for details, and your server's documentation
- *                              for possible values.  node-amqp-encoder'd maps will be translated, and simple maps will be converted
- *                              to AMQP Fields type as defined in the spec.
+ * @param {String} [source]     Source of the link to connect to.  If not provided will use default queue from connection uri.
+ * @param {Object} [options]    Link policy used for creating this receiver link
  *
  * @return {Promise}
  */
@@ -244,19 +240,7 @@ AMQPClient.prototype.createReceiver = function(address, options) {
           source: { address: address.name },
           target: { address: 'localhost' }
         }
-      }, this.policy.receiverLink);
-
-  if (options) {
-    if (options.filter && options.filter instanceof Array && options[0] === 'map') {
-      // Convert encoded values
-      options.filter = AMQPClient.adapters.Translator(options.filter);
-      linkPolicy.source.filter = options.filter;
-    }
-
-    if (options.policy) {
-      linkPolicy = u.deepMerge(options.policy, linkPolicy);
-    }
-  }
+      }, options, this.policy.receiverLink);
 
   // if a subject has been provided then automatically set up a filter to match
   // on that subject.

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -47,7 +47,7 @@ var EventEmitter = require('events').EventEmitter,
  var AMQPClient = require('amqp10').Client;
  var client = new AMQPClient(AMQPClient.policies.merge({
    senderLink: {
-     options: {
+     attach: {
        senderSettleMode: AMQPClient.constants.senderSettleMode.settled
      }
    }
@@ -172,8 +172,9 @@ AMQPClient.prototype.connect = function(url) {
  * Creates a sender link for the given address, with optional link policy
  *
  * @method createSender
- * @param {String} address              An address to connect this link to. If not provided will use default queue from connection uri.
- * @param {Object} [policyOverrides]    Policy overrides used for creating this sender link
+ * @param {String} address                An address to connect this link to. If not provided will use default queue from connection uri.
+ * @param {Object} [policyOverrides]      Policy overrides used for creating this sender link
+ * @param {String} [policyOverrides.name] Explicitly set a name for this link, this is an alias to [policyOverrides.attach.name]
  *
  * @return {Promise}
  */
@@ -187,7 +188,7 @@ AMQPClient.prototype.createSender = function(address, policyOverrides) {
 
   var linkName = u.linkName(address.name, policyOverrides),
       linkPolicy = u.deepMerge({
-        options: {
+        attach: {
           name: linkName,
           source: { address: 'localhost' },
           target: { address: address.name }
@@ -220,8 +221,9 @@ AMQPClient.prototype.createSender = function(address, policyOverrides) {
  * used to listen for 'message' events.
  *
  * @method createReceiver
- * @param {String} address              An address to connect this link to.  If not provided will use default queue from connection uri.
- * @param {Object} [policyOverrides]    Policy overrides used for creating this receiver link
+ * @param {String} address                An address to connect this link to.  If not provided will use default queue from connection uri.
+ * @param {Object} [policyOverrides]      Policy overrides used for creating this receiver link
+ * @param {String} [policyOverrides.name] Explicitly set a name for this link, this is an alias to [policyOverrides.attach.name]
  *
  * @return {Promise}
  */
@@ -235,7 +237,7 @@ AMQPClient.prototype.createReceiver = function(address, policyOverrides) {
 
   var linkName = u.linkName(address.name, policyOverrides),
       linkPolicy = u.deepMerge({
-        options: {
+        attach: {
           name: linkName,
           source: { address: address.name },
           target: { address: 'localhost' }
@@ -249,7 +251,7 @@ AMQPClient.prototype.createReceiver = function(address, policyOverrides) {
       'apache.org:legacy-amqp-topic-binding:string' :
       'apache.org:legacy-amqp-direct-binding:string';
 
-    linkPolicy.options.source.filter = AMQPClient.adapters.Translator([
+    linkPolicy.attach.source.filter = AMQPClient.adapters.Translator([
       'described', ['symbol', filterSymbol], ['string', address.subject]
     ]);
   }

--- a/lib/frames/attach_frame.js
+++ b/lib/frames/attach_frame.js
@@ -169,8 +169,9 @@ function AttachFrame(options) {
   }
 
   u.assertArguments(options, ['name', 'handle', 'role']);
-  if (!options.source && !options.target)
+  if (!options.source && !options.target) {
     throw new errors.ArgumentError('source|target');
+  }
 
   if (options.role === constants.linkRole.sender &&
       options.initialDeliveryCount === undefined)

--- a/lib/frames/detach_frame.js
+++ b/lib/frames/detach_frame.js
@@ -50,8 +50,7 @@ var debug = require('debug')('amqp10:framing:detach'),
  * @constructor
  */
 function DetachFrame(options) {
-  DetachFrame.super_.call(this);
-  this.channel = 0;
+  DetachFrame.super_.call(this, options.channel);
   if (options instanceof DescribedType) {
     this.readPerformative(options);
     return;

--- a/lib/link.js
+++ b/lib/link.js
@@ -92,7 +92,7 @@ Link.prototype.state = function() {
 
 Link.prototype.attach = function() {
   this.linkSM.sendAttach();
-  var attachFrame = new AttachFrame(this.policy.options);
+  var attachFrame = new AttachFrame(this.policy.attach);
   attachFrame.channel = this.session.channel;
   debug('attach CH=' + attachFrame.channel + ', Handle=' + attachFrame.handle);
 
@@ -165,9 +165,12 @@ Link.prototype._detachReceived = function(frame) {
 };
 
 Link.prototype._sendDetach = function() {
-  var detachFrame = new DetachFrame(this.policy.options);
-  detachFrame.channel = this.session.channel;
-  detachFrame.closed = true;
+  var detachFrame = new DetachFrame({
+    handle: this.handle,
+    channel: this.session.channel,
+    closed: true
+  });
+
   this.session.connection.sendFrame(detachFrame);
 };
 

--- a/lib/policies/default_policy.js
+++ b/lib/policies/default_policy.js
@@ -69,7 +69,7 @@ module.exports = {
     enableSessionFlowControl: true
   },
   senderLink: {
-    options: {
+    attach: {
       name: linkName('sender'),
       role: constants.linkRole.sender,
       senderSettleMode: constants.senderSettleMode.mixed,
@@ -81,11 +81,12 @@ module.exports = {
     reattach: null
   },
   receiverLink: {
-    options: {
+    attach: {
       name: linkName('receiver'),
       role: constants.linkRole.receiver,
       receiverSettleMode: constants.receiverSettleMode.autoSettle,
-      maxMessageSize: 10000 // Arbitrary choice
+      maxMessageSize: 10000, // Arbitrary choice
+      initialDeliveryCount: 1
     },
     credit: putils.CreditPolicies.RefreshAtHalf,
     creditQuantum: 100,

--- a/lib/policies/service_bus_policy.js
+++ b/lib/policies/service_bus_policy.js
@@ -7,12 +7,9 @@ var constants = require('../constants'),
 module.exports = u.deepMerge({
   defaultSubjects: false,
   senderLink: {
-    options: {
-      role: constants.linkRole.sender,
+    attach: {
       senderSettleMode: constants.senderSettleMode.settled,
-      receiverSettleMode: constants.receiverSettleMode.autoSettle,
       maxMessageSize: 10000, // Arbitrary choice
-      initialDeliveryCount: 1
     },
     encoder: function(body) {
       var bodyStr = body;
@@ -28,13 +25,6 @@ module.exports = u.deepMerge({
     }
   },
   receiverLink: {
-    options: {
-      role: constants.linkRole.receiver,
-      senderSettleMode: constants.senderSettleMode.settled,
-      receiverSettleMode: constants.receiverSettleMode.autoSettle,
-      maxMessageSize: 10000, // Arbitrary choice
-      initialDeliveryCount: 1
-    },
     decoder: function(body) {
       var bodyStr = null;
       if (body instanceof Buffer) {

--- a/lib/receiver_link.js
+++ b/lib/receiver_link.js
@@ -145,7 +145,7 @@ ReceiverLink.prototype._messageReceived = function(transferFrame) {
   transferFrame.message._deliveryId = transferFrame.deliveryId;
 
   // respect settle mode in policy
-  if (this.policy.options.receiverSettleMode === constants.receiverSettleMode.autoSettle) {
+  if (this.policy.attach.receiverSettleMode === constants.receiverSettleMode.autoSettle) {
     this.accept(transferFrame.message);
   }
 

--- a/lib/sender_link.js
+++ b/lib/sender_link.js
@@ -25,7 +25,7 @@ util.inherits(SenderLink, Link);
 
 // public API
 SenderLink.prototype.attach = function() {
-  this.initialDeliveryCount = this.policy.options.initialDeliveryCount;
+  this.initialDeliveryCount = this.policy.attach.initialDeliveryCount;
   this.deliveryCount = 0;
 
   // call super method

--- a/lib/session.js
+++ b/lib/session.js
@@ -201,22 +201,23 @@ Session.prototype.begin = function(sessionPolicy) {
 };
 
 Session.prototype.createLink = function(linkPolicy) {
-  var policy = u.deepMerge(linkPolicy);
+  var policy = u.deepMerge(linkPolicy),
+      attachOptions = policy.attach || {};
 
-  policy.options.handle = this._nextHandle();
-  if (typeof policy.options.name === 'function')
-    policy.options.name = policy.options.name();
+  attachOptions.handle = this._nextHandle();
+  if (typeof attachOptions.name === 'function')
+    attachOptions.name = attachOptions.name();
 
   var link;
-  if (policy.options.role === constants.linkRole.sender) {
-    link = new SenderLink(this, policy.options.handle, policy);
-    this._senderLinks[policy.options.name] = link;
+  if (attachOptions.role === constants.linkRole.sender) {
+    link = new SenderLink(this, attachOptions.handle, policy);
+    this._senderLinks[attachOptions.name] = link;
   } else {
-    link = new ReceiverLink(this, policy.options.handle, policy);
-    this._receiverLinks[policy.options.name] = link;
+    link = new ReceiverLink(this, attachOptions.handle, policy);
+    this._receiverLinks[attachOptions.name] = link;
   }
 
-  this._allocatedHandles[policy.options.handle] = link;
+  this._allocatedHandles[attachOptions.handle] = link;
 
   var self = this;
   link.on(Link.Detached, function(details) {
@@ -240,7 +241,7 @@ Session.prototype.createLink = function(linkPolicy) {
 /// Remove a link from the sender
 ///
 Session.prototype._removeLink = function(link) {
-  delete this._allocatedHandles[link.policy.options.handle];
+  delete this._allocatedHandles[link.handle];
   if (link instanceof SenderLink) {
     debug('Removing sender link ' + link.name);
     delete this._senderLinks[link.name];

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -290,9 +290,10 @@ module.exports.dispositionRange = function(message) {
  * Generates a link name for a given address
  *
  * @param address   link address
- * @param options   link creation options
+ * @param options   link creation policy
  * @return String
  */
-module.exports.linkName = function(address, options) {
-  return ((!!options && !!options.name) ? options.name : address + '_' + uuid.v4());
+module.exports.linkName = function(address, policy) {
+  return ((!!policy && !!policy.options && !!policy.options.name) ?
+    policy.options.name : address + '_' + uuid.v4());
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -289,11 +289,11 @@ module.exports.dispositionRange = function(message) {
 /**
  * Generates a link name for a given address
  *
- * @param address   link address
- * @param options   link creation policy
- * @return String
+ * @param address             link address
+ * @param [policyOverrides]   link creation policy overrides
+ * @return {String}
  */
-module.exports.linkName = function(address, policy) {
-  return ((!!policy && !!policy.options && !!policy.options.name) ?
-    policy.options.name : address + '_' + uuid.v4());
+module.exports.linkName = function(address, policyOverrides) {
+  return ((!!policyOverrides && !!policyOverrides.name) ?
+    policyOverrides.name : address + '_' + uuid.v4());
 };

--- a/test/integration/qpid/disposition.test.js
+++ b/test/integration/qpid/disposition.test.js
@@ -69,12 +69,10 @@ describe('Disposition', function() {
         return Promise.all([
           test.broker.initialize(),
           test.client.createReceiver(queueName, {
-            policy: {
-              options: {
-                receiverSettleMode: c.receiverSettleMode.settleOnDisposition
-              },
-              creditQuantum: 1
-            }
+            options: {
+              receiverSettleMode: c.receiverSettleMode.settleOnDisposition
+            },
+            creditQuantum: 1
           }),
           test.client.createSender(queueName)
         ]);

--- a/test/integration/qpid/disposition.test.js
+++ b/test/integration/qpid/disposition.test.js
@@ -69,7 +69,7 @@ describe('Disposition', function() {
         return Promise.all([
           test.broker.initialize(),
           test.client.createReceiver(queueName, {
-            options: {
+            attach: {
               receiverSettleMode: c.receiverSettleMode.settleOnDisposition
             },
             creditQuantum: 1

--- a/test/unit/mocks/session.js
+++ b/test/unit/mocks/session.js
@@ -19,12 +19,13 @@ MockSession.prototype.begin = function(policy) {
 };
 
 MockSession.prototype.createLink = function(policy) {
-  var link = this._mockLinks[policy.options.name];
+  var link = this._mockLinks[policy.attach.name];
   expect(link).to.exist;
 
   link._created++;
   link._clearState();
   link.attached = true;
+  link.handle = policy.attach.handle;
   this.emit('attachLink-called', this, policy, link);
   return link;
 };

--- a/test/unit/test_amqpclient.js
+++ b/test/unit/test_amqpclient.js
@@ -106,7 +106,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function () {
-          return client.createSender(queue, { options: { name: 'queue_TX' } });
+          return client.createSender(queue, { name: 'queue_TX' });
         })
         .then(function (sender) {
           return Promise.all([
@@ -176,7 +176,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function () {
-          return client.createSender(queue, { options: { name: 'queue_TX' } });
+          return client.createSender(queue, { name: 'queue_TX' });
         })
         .then(function (sender) {
           return Promise.all([
@@ -253,8 +253,8 @@ describe('AMQPClient', function() {
       return client.connect(mock_uri)
         .then(function() {
           return Promise.all([
-            client.createReceiver('queue1', { options: { name: 'queue1_RX' } }),
-            client.createReceiver('queue2', { options: { name: 'queue2_RX' } })
+            client.createReceiver('queue1', { name: 'queue1_RX' }),
+            client.createReceiver('queue2', { name: 'queue2_RX' })
           ]);
         })
         .then(function() {
@@ -314,7 +314,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function() {
-          return client.createReceiver(queue, { options: { name: 'queue_RX' } });
+          return client.createReceiver(queue, { name: 'queue_RX' });
         })
         .then(function() {
           process.nextTick(function() {
@@ -373,7 +373,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function() {
-          return client.createReceiver(queue, { options: { name: 'queue_RX' } });
+          return client.createReceiver(queue, { name: 'queue_RX' });
         })
         .then(function() {
           process.nextTick(function() {

--- a/test/unit/test_amqpclient.js
+++ b/test/unit/test_amqpclient.js
@@ -106,7 +106,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function () {
-          return client.createSender(queue, { name: 'queue_TX' });
+          return client.createSender(queue, { options: { name: 'queue_TX' } });
         })
         .then(function (sender) {
           return Promise.all([
@@ -176,7 +176,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function () {
-          return client.createSender(queue, { name: 'queue_TX' });
+          return client.createSender(queue, { options: { name: 'queue_TX' } });
         })
         .then(function (sender) {
           return Promise.all([
@@ -253,8 +253,8 @@ describe('AMQPClient', function() {
       return client.connect(mock_uri)
         .then(function() {
           return Promise.all([
-            client.createReceiver('queue1', { name: 'queue1_RX' }),
-            client.createReceiver('queue2', { name: 'queue2_RX' })
+            client.createReceiver('queue1', { options: { name: 'queue1_RX' } }),
+            client.createReceiver('queue2', { options: { name: 'queue2_RX' } })
           ]);
         })
         .then(function() {
@@ -314,7 +314,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function() {
-          return client.createReceiver(queue, { name: 'queue_RX' });
+          return client.createReceiver(queue, { options: { name: 'queue_RX' } });
         })
         .then(function() {
           process.nextTick(function() {
@@ -373,7 +373,7 @@ describe('AMQPClient', function() {
 
       return client.connect(mock_uri)
         .then(function() {
-          return client.createReceiver(queue, { name: 'queue_RX' });
+          return client.createReceiver(queue, { options: { name: 'queue_RX' } });
         })
         .then(function() {
           process.nextTick(function() {

--- a/test/unit/test_amqpclient.js
+++ b/test/unit/test_amqpclient.js
@@ -88,8 +88,8 @@ describe('AMQPClient', function() {
 
       s.on('attachLink-called', function (_s, _policy, _l) {
         called.attachLink++;
-        expect(_policy.options.target).to.eql({address: queue});
-        expect(_policy.options.role).to.eql(constants.linkRole.sender);
+        expect(_policy.attach.target).to.eql({address: queue});
+        expect(_policy.attach.role).to.eql(constants.linkRole.sender);
 
         process.nextTick(function() {
           _l.simulateAttaching();
@@ -160,8 +160,8 @@ describe('AMQPClient', function() {
 
       s.on('attachLink-called', function (_s, _policy, _l) {
         called.attachLink++;
-        expect(_policy.options.target).to.eql({address: queue});
-        expect(_policy.options.role).to.eql(constants.linkRole.sender);
+        expect(_policy.attach.target).to.eql({address: queue});
+        expect(_policy.attach.role).to.eql(constants.linkRole.sender);
         if (called.attachLink === 1) {
           process.nextTick(function() {
             _l.emit(Link.Detached);
@@ -243,7 +243,7 @@ describe('AMQPClient', function() {
 
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
-        expect(_policy.options.role).to.eql(constants.linkRole.receiver);
+        expect(_policy.attach.role).to.eql(constants.linkRole.receiver);
 
         process.nextTick(function() {
           _l.simulateAttaching();
@@ -298,8 +298,8 @@ describe('AMQPClient', function() {
 
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
-        expect(_policy.options.source).to.eql({ address: queue });
-        expect(_policy.options.role).to.eql(constants.linkRole.receiver);
+        expect(_policy.attach.source).to.eql({ address: queue });
+        expect(_policy.attach.role).to.eql(constants.linkRole.receiver);
         if (called.attachLink === 1) {
           process.nextTick(function() {
             _l.emit(Link.Detached);
@@ -358,8 +358,8 @@ describe('AMQPClient', function() {
 
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
-        expect(_policy.options.source).to.eql({ address: queue });
-        expect(_policy.options.role).to.eql(constants.linkRole.receiver);
+        expect(_policy.attach.source).to.eql({ address: queue });
+        expect(_policy.attach.role).to.eql(constants.linkRole.receiver);
         if (called.attachLink === 1) {
           process.nextTick(function() {
             c.emit(Connection.Disconnected);

--- a/test/unit/test_session.js
+++ b/test/unit/test_session.js
@@ -25,8 +25,8 @@ var debug = require('debug')('amqp10-test_connection'),
     MockServer = require('./mock_amqp');
 
 DefaultPolicy.connect.options.containerId = 'test';
-DefaultPolicy.senderLink.options.name = 'sender';
-DefaultPolicy.receiverLink.options.name = 'receiver';
+DefaultPolicy.senderLink.attach.name = 'sender';
+DefaultPolicy.receiverLink.attach.name = 'receiver';
 
 function MockBeginFrame(options, channel) {
   var begin = new BeginFrame(u.deepMerge(options, DefaultPolicy.session.options));
@@ -39,8 +39,8 @@ function tgt() { return { address: 'test-tgt' }; }
 
 function MockAttachFrame(options, channel) {
   var defaults = options.role === constants.linkRole.sender ?
-      DefaultPolicy.senderLink.options :
-      DefaultPolicy.receiverLink.options;
+      DefaultPolicy.senderLink.attach :
+      DefaultPolicy.receiverLink.attach;
 
   var opts = u.deepMerge({
     name: 'test',
@@ -222,7 +222,7 @@ describe('Session', function() {
         }));
 
         session.on(Session.Mapped, function() {
-          var opts = u.deepMerge({ options: { name: 'test', source: src(), target: tgt() } }, DefaultPolicy.senderLink);
+          var opts = u.deepMerge({ attach: { name: 'test', source: src(), target: tgt() } }, DefaultPolicy.senderLink);
           var link = session.createLink(opts);
           link.on('errorReceived', function(err) {
             expect(err).to.eql(new AMQPError(AMQPError.LinkDetachForced, 'test', ''));


### PR DESCRIPTION
see #149 

includes:
  * renaming `options` to `policyOverrides`
  * renaming `senderLinkPolicy.options` and `receiverLinkPolicy.options` to `attach`