### PR TITLE
feat(SenderLink): accept a full message as the first param for send

### DIFF
--- a/lib/frames/attach_frame.js
+++ b/lib/frames/attach_frame.js
@@ -199,6 +199,12 @@ AttachFrame.prototype.Descriptor = {
   code: new Int64(0x00000000, 0x00000012)
 };
 
+AttachFrame.prototype.EncodeOrdering = [
+  'name', 'handle', 'role', 'senderSettleMode', 'receiverSettleMode',
+  'source', 'target', 'unsettled', 'incompleteUnsettled', 'initialDeliveryCount',
+  'maxMessageSize', 'offeredCapabilities', 'desiredCapabilities', 'properties'
+];
+
 AttachFrame.prototype._getPerformative = function() {
   var self = this;
   var performative = new DescribedType(AttachFrame, {
@@ -216,28 +222,20 @@ AttachFrame.prototype._getPerformative = function() {
     offeredCapabilities: self.offeredCapabilities,
     desiredCapabilities: self.desiredCapabilities,
     properties: self.properties,
-    encodeOrdering: ['name', 'handle', 'role', 'senderSettleMode', 'receiverSettleMode', 'source', 'target', 'unsettled',
-      'incompleteUnsettled', 'initialDeliveryCount', 'maxMessageSize', 'offeredCapabilities', 'desiredCapabilities', 'properties']
+    encodeOrdering: AttachFrame.prototype.EncodeOrdering
   });
   return performative;
 };
 
 AttachFrame.prototype.readPerformative = function(describedType) {
-  var idx = 0;
-  this.name = up.get(describedType, idx++);
-  this.handle = up.get(describedType, idx++);
-  this.role = up.get(describedType, idx++);
-  this.senderSettleMode = up.onUndef(describedType, idx++, constants.senderSettleMode.mixed);
-  this.receiverSettleMode = up.onUndef(describedType, idx++, constants.receiverSettleMode.autoSettle);
-  this.source = up.orNull(describedType, idx++);
-  this.target = up.orNull(describedType, idx++);
-  this.unsettled = up.onUndef(describedType, idx++, {});
-  this.incompleteUnsettled = up.orFalse(describedType, idx++);
-  this.initialDeliveryCount = up.get(describedType, idx++);
-  this.maxMessageSize = up.onUndef(describedType, idx++, 0);
-  this.offeredCapabilities = up.orNull(describedType, idx++);
-  this.desiredCapabilities = up.orNull(describedType, idx++);
-  this.properties = up.onUndef(describedType, idx++, {});
+  u.assignDescribedTypeFromPayload(AttachFrame, this, describedType, {
+    senderSettleMode: constants.senderSettleMode.mixed,
+    receiverSettleMode: constants.receiverSettleMode.autoSettle,
+    unsettled: {},
+    incompleteUnsettled: false,
+    maxMessageSize: 0,
+    properties: {}
+  });
 };
 
 module.exports = AttachFrame;

--- a/lib/frames/attach_frame.js
+++ b/lib/frames/attach_frame.js
@@ -228,7 +228,7 @@ AttachFrame.prototype._getPerformative = function() {
 };
 
 AttachFrame.prototype.readPerformative = function(describedType) {
-  u.assignDescribedTypeFromPayload(AttachFrame, this, describedType, {
+  u.assignFromDescribedType(AttachFrame, describedType, this, {
     senderSettleMode: constants.senderSettleMode.mixed,
     receiverSettleMode: constants.receiverSettleMode.autoSettle,
     unsettled: {},

--- a/lib/frames/begin_frame.js
+++ b/lib/frames/begin_frame.js
@@ -129,7 +129,7 @@ BeginFrame.prototype._getPerformative = function() {
 };
 
 BeginFrame.prototype.readPerformative = function(describedType) {
-  u.assignDescribedTypeFromPayload(BeginFrame, this, describedType, {
+  u.assignFromDescribedType(BeginFrame, describedType, this, {
     handleMax: constants.defaultHandleMax,
     properties: {}
   });

--- a/lib/frames/begin_frame.js
+++ b/lib/frames/begin_frame.js
@@ -108,6 +108,11 @@ BeginFrame.prototype.Descriptor = {
   code: new Int64(0x00000000, 0x00000011)
 };
 
+BeginFrame.prototype.EncodeOrdering = [
+  'remoteChannel', 'nextOutgoingId', 'incomingWindow', 'outgoingWindow',
+  'handleMax', 'offeredCapabilities', 'desiredCapabilities', 'properties'
+];
+
 BeginFrame.prototype._getPerformative = function() {
   var self = this;
   return new DescribedType(BeginFrame, {
@@ -119,23 +124,15 @@ BeginFrame.prototype._getPerformative = function() {
     offeredCapabilities: self.offeredCapabilities, /* symbol */
     desiredCapabilities: self.desiredCapabilities, /* symbol */
     properties: self.properties,
-    encodeOrdering: [
-      'remoteChannel', 'nextOutgoingId', 'incomingWindow', 'outgoingWindow',
-      'handleMax', 'offeredCapabilities', 'desiredCapabilities', 'properties'
-    ]
+    encodeOrdering: BeginFrame.prototype.EncodeOrdering
   });
 };
 
 BeginFrame.prototype.readPerformative = function(describedType) {
-  var idx = 0;
-  this.remoteChannel = up.get(describedType, idx++);
-  this.nextOutgoingId = up.get(describedType, idx++);
-  this.incomingWindow = up.get(describedType, idx++);
-  this.outgoingWindow = up.get(describedType, idx++);
-  this.handleMax = up.onUndef(describedType, idx++, constants.defaultHandleMax);
-  this.offeredCapabilities = up.orNull(describedType, idx++);
-  this.desiredCapabilities = up.orNull(describedType, idx++);
-  this.properties = up.onUndef(describedType, idx++, {});
+  u.assignDescribedTypeFromPayload(BeginFrame, this, describedType, {
+    handleMax: constants.defaultHandleMax,
+    properties: {}
+  });
 };
 
 module.exports = BeginFrame;

--- a/lib/frames/detach_frame.js
+++ b/lib/frames/detach_frame.js
@@ -70,23 +70,23 @@ DetachFrame.prototype.Descriptor = {
   code: new Int64(0x00000000, 0x00000016)
 };
 
+DetachFrame.prototype.EncodeOrdering = ['handle', 'closed', 'error'];
+
 DetachFrame.prototype._getPerformative = function() {
   var self = this;
   return new DescribedType(DetachFrame, {
     handle: new ForcedType('uint', self.handle),
     closed: self.closed,
     error: self.error,
-    encodeOrdering: ['handle', 'closed', 'error']
+    encodeOrdering: DetachFrame.prototype.EncodeOrdering
   });
 };
 
 DetachFrame.prototype.readPerformative = function(describedType) {
   up.assert(describedType, 0, 'handle');
-
-  var idx = 0;
-  this.handle = up.get(describedType, idx++);
-  this.closed = up.orFalse(describedType, idx++);
-  this.error = up.get(describedType, idx++);
+  u.assignDescribedTypeFromPayload(DetachFrame, this, describedType, {
+    closed: false
+  });
 };
 
 module.exports = DetachFrame;

--- a/lib/frames/detach_frame.js
+++ b/lib/frames/detach_frame.js
@@ -84,7 +84,7 @@ DetachFrame.prototype._getPerformative = function() {
 
 DetachFrame.prototype.readPerformative = function(describedType) {
   up.assert(describedType, 0, 'handle');
-  u.assignDescribedTypeFromPayload(DetachFrame, this, describedType, {
+  u.assignFromDescribedType(DetachFrame, describedType, this, {
     closed: false
   });
 };

--- a/lib/frames/disposition_frame.js
+++ b/lib/frames/disposition_frame.js
@@ -132,7 +132,7 @@ DispositionFrame.prototype.readPerformative = function(describedType) {
   up.assert(describedType, 0, 'role');
   up.assert(describedType, 1, 'first');
 
-  u.assignDescribedTypeFromPayload(DispositionFrame, this, describedType, {
+  u.assignFromDescribedType(DispositionFrame, describedType, this, {
     settled: false,
     batchable: false
   });

--- a/lib/frames/disposition_frame.js
+++ b/lib/frames/disposition_frame.js
@@ -111,6 +111,10 @@ DispositionFrame.prototype.Descriptor = {
   code: new Int64(0x00000000, 0x00000015)
 };
 
+DispositionFrame.prototype.EncodeOrdering = [
+  'role', 'first', 'last', 'settled', 'state', 'batchable'
+];
+
 DispositionFrame.prototype._getPerformative = function() {
   var self = this;
   return new DescribedType(DispositionFrame, {
@@ -120,7 +124,7 @@ DispositionFrame.prototype._getPerformative = function() {
     settled: self.settled,
     state: self.state,
     batchable: self.batchable,
-    encodeOrdering: ['role', 'first', 'last', 'settled', 'state', 'batchable']
+    encodeOrdering: DispositionFrame.prototype.EncodeOrdering
   });
 };
 
@@ -128,13 +132,10 @@ DispositionFrame.prototype.readPerformative = function(describedType) {
   up.assert(describedType, 0, 'role');
   up.assert(describedType, 1, 'first');
 
-  var idx = 0;
-  this.role = up.get(describedType, idx++);
-  this.first = up.get(describedType, idx++);
-  this.last = up.get(describedType, idx++);
-  this.settled = up.orFalse(describedType, idx++);
-  this.state = up.get(describedType, idx++);
-  this.batchable = up.orFalse(describedType, idx++);
+  u.assignDescribedTypeFromPayload(DispositionFrame, this, describedType, {
+    settled: false,
+    batchable: false
+  });
 };
 
 module.exports = DispositionFrame;

--- a/lib/frames/flow_frame.js
+++ b/lib/frames/flow_frame.js
@@ -170,6 +170,12 @@ FlowFrame.prototype.Descriptor = {
   code: new Int64(0x00000000, 0x00000013)
 };
 
+FlowFrame.prototype.EncodeOrdering = [
+  'nextIncomingId', 'incomingWindow', 'nextOutgoingId', 'outgoingWindow',
+  'handle', 'deliveryCount', 'linkCredit', 'available', 'drain', 'echo',
+  'properties'
+];
+
 FlowFrame.prototype._getPerformative = function() {
   var self = this;
   return new DescribedType(FlowFrame, {
@@ -184,8 +190,7 @@ FlowFrame.prototype._getPerformative = function() {
     drain: self.drain,
     echo: self.echo,
     properties: self.properties,
-    encodeOrdering: ['nextIncomingId', 'incomingWindow', 'nextOutgoingId', 'outgoingWindow', 'handle',
-      'deliveryCount', 'linkCredit', 'available', 'drain', 'echo', 'properties']
+    encodeOrdering: FlowFrame.prototype.EncodeOrdering
   });
 };
 
@@ -194,18 +199,11 @@ FlowFrame.prototype.readPerformative = function(describedType) {
   up.assert(describedType, 2, 'nextOutgoingId');
   up.assert(describedType, 3, 'outgoingWindow');
 
-  var idx = 0;
-  this.nextIncomingId = up.orNull(describedType, idx++);
-  this.incomingWindow = up.get(describedType, idx++);
-  this.nextOutgoingId = up.get(describedType, idx++);
-  this.outgoingWindow = up.get(describedType, idx++);
-  this.handle = up.orNull(describedType, idx++);
-  this.deliveryCount = up.orNull(describedType, idx++);
-  this.linkCredit = up.orNull(describedType, idx++);
-  this.available = up.orNull(describedType, idx++);
-  this.drain = up.orFalse(describedType, idx++);
-  this.echo = up.orFalse(describedType, idx++);
-  this.properties = up.onUndef(describedType, idx++, {});
+  u.assignDescribedTypeFromPayload(FlowFrame, this, describedType, {
+    drain: false,
+    echo: false,
+    properties: {}
+  });
 };
 
 module.exports = FlowFrame;

--- a/lib/frames/flow_frame.js
+++ b/lib/frames/flow_frame.js
@@ -199,7 +199,7 @@ FlowFrame.prototype.readPerformative = function(describedType) {
   up.assert(describedType, 2, 'nextOutgoingId');
   up.assert(describedType, 3, 'outgoingWindow');
 
-  u.assignDescribedTypeFromPayload(FlowFrame, this, describedType, {
+  u.assignFromDescribedType(FlowFrame, describedType, this, {
     drain: false,
     echo: false,
     properties: {}

--- a/lib/frames/open_frame.js
+++ b/lib/frames/open_frame.js
@@ -200,7 +200,7 @@ OpenFrame.prototype._getPerformative = function() {
 };
 
 OpenFrame.prototype.readPerformative = function(describedType) {
-  u.assignDescribedTypeFromPayload(OpenFrame, this, describedType, {
+  u.assignFromDescribedType(OpenFrame, describedType, this, {
     maxFrameSize: constants.defaultMaxFrameSize,
     channelMax: constants.defaultChannelMax,
     idleTimeout: 0,

--- a/lib/frames/open_frame.js
+++ b/lib/frames/open_frame.js
@@ -175,6 +175,12 @@ OpenFrame.prototype.Descriptor = {
   code: new Int64(0x00000000, 0x00000010)
 };
 
+OpenFrame.prototype.EncodeOrdering = [
+  'id', 'hostname', 'maxFrameSize', 'channelMax', 'idleTimeout',
+  'outgoingLocales', 'incomingLocales', 'offeredCapabilities',
+  'desiredCapabilities', 'properties'
+];
+
 OpenFrame.prototype._getPerformative = function() {
   var self = this;
   u.assertArguments(self, ['id', 'hostname']);
@@ -189,23 +195,19 @@ OpenFrame.prototype._getPerformative = function() {
     offeredCapabilities: self.offeredCapabilities,
     desiredCapabilities: self.desiredCapabilities,
     properties: self.properties,
-    encodeOrdering: ['id', 'hostname', 'maxFrameSize', 'channelMax', 'idleTimeout', 'outgoingLocales',
-      'incomingLocales', 'offeredCapabilities', 'desiredCapabilities', 'properties']
+    encodeOrdering: OpenFrame.prototype.EncodeOrdering
   });
 };
 
 OpenFrame.prototype.readPerformative = function(describedType) {
-  var idx = 0;
-  this.id = up.get(describedType, idx++);
-  this.hostname = up.orNull(describedType, idx++);
-  this.maxFrameSize = up.onUndef(describedType, idx++, constants.defaultMaxFrameSize);
-  this.channelMax = up.onUndef(describedType, idx++, constants.defaultChannelMax);
-  this.idleTimeout = up.onUndef(describedType, idx++, 0);
-  this.outgoingLocales = up.onUndef(describedType, idx++, [constants.requiredLocale]);
-  this.incomingLocales = up.onUndef(describedType, idx++, [constants.requiredLocale]);
-  this.offeredCapabilities = up.orNull(describedType, idx++);
-  this.desiredCapabilities = up.orNull(describedType, idx++);
-  this.properties = up.onUndef(describedType, idx++, {});
+  u.assignDescribedTypeFromPayload(OpenFrame, this, describedType, {
+    maxFrameSize: constants.defaultMaxFrameSize,
+    channelMax: constants.defaultChannelMax,
+    idleTimeout: 0,
+    outgoingLocales: [constants.requiredLocale],
+    incomingLocales: [constants.requiredLocale],
+    properties: {}
+  });
 };
 
 module.exports = OpenFrame;

--- a/lib/frames/transfer_frame.js
+++ b/lib/frames/transfer_frame.js
@@ -240,7 +240,7 @@ TransferFrame.prototype._getPerformative = function() {
 TransferFrame.prototype.readPerformative = function(describedType) {
   up.assert(describedType, 0, 'handle');
 
-  u.assignDescribedTypeFromPayload(TransferFrame, this, describedType, {
+  u.assignFromDescribedType(TransferFrame, describedType, this, {
     more: false,
     resume: false,
     aborted: false,

--- a/lib/frames/transfer_frame.js
+++ b/lib/frames/transfer_frame.js
@@ -214,6 +214,11 @@ TransferFrame.prototype.Descriptor = {
   code: new Int64(0x00000000, 0x00000014)
 };
 
+TransferFrame.prototype.EncodeOrdering = [
+  'handle', 'deliveryId', 'deliveryTag', 'messageFormat', 'settled', 'more',
+  'receiverSettleMode', 'state', 'resume', 'aborted', 'batchable'
+];
+
 TransferFrame.prototype._getPerformative = function() {
   var self = this;
   return new DescribedType(TransferFrame, {
@@ -228,26 +233,19 @@ TransferFrame.prototype._getPerformative = function() {
     resume: self.resume,
     aborted: self.aborted,
     batchable: self.batchable,
-    encodeOrdering: ['handle', 'deliveryId', 'deliveryTag', 'messageFormat', 'settled', 'more',
-      'receiverSettleMode', 'state', 'resume', 'aborted', 'batchable']
+    encodeOrdering: TransferFrame.prototype.EncodeOrdering
   });
 };
 
 TransferFrame.prototype.readPerformative = function(describedType) {
   up.assert(describedType, 0, 'handle');
 
-  var idx = 0;
-  this.handle = up.get(describedType, idx++);
-  this.deliveryId = up.orNull(describedType, idx++);
-  this.deliveryTag = up.orNull(describedType, idx++);
-  this.messageFormat = up.orNull(describedType, idx++);
-  this.settled = up.orNull(describedType, idx++);
-  this.more = up.orFalse(describedType, idx++);
-  this.receiverSettleMode = up.orNull(describedType, idx++);
-  this.state = up.orNull(describedType, idx++);
-  this.resume = up.orFalse(describedType, idx++);
-  this.aborted = up.orFalse(describedType, idx++);
-  this.batchable = up.orFalse(describedType, idx++);
+  u.assignDescribedTypeFromPayload(TransferFrame, this, describedType, {
+    more: false,
+    resume: false,
+    aborted: false,
+    batchable: false
+  });
 };
 
 TransferFrame.prototype._getAdditionalPayload = function() {

--- a/lib/sender_link.js
+++ b/lib/sender_link.js
@@ -71,7 +71,15 @@ SenderLink.prototype.send = function(msg, options) {
 
   var self = this;
   return new Promise(function(resolve, reject) {
-    var message = new M.Message(options, self.policy.encoder(msg));
+    var message;
+    if (_.isObject(msg) && msg.hasOwnProperty('body')) {
+      msg.body = self.policy.encoder(msg.body);
+      message = new M.Message(msg);
+    } else {
+      message = new M.Message(options, self.policy.encoder(msg));
+    }
+
+
     var deliveryTag = self.session._deliveryTag++;
 
     var sendMessage = function(err) {

--- a/lib/sender_link.js
+++ b/lib/sender_link.js
@@ -73,12 +73,11 @@ SenderLink.prototype.send = function(msg, options) {
   return new Promise(function(resolve, reject) {
     var message;
     if (_.isObject(msg) && msg.hasOwnProperty('body')) {
-      msg.body = self.policy.encoder(msg.body);
       message = new M.Message(msg);
+      message.body = self.policy.encoder(message.body);
     } else {
       message = new M.Message(options, self.policy.encoder(msg));
     }
-
 
     var deliveryTag = self.session._deliveryTag++;
 

--- a/lib/types/message.js
+++ b/lib/types/message.js
@@ -43,7 +43,9 @@ Header.prototype.EncodeOrdering = [
 ];
 
 Header.fromDescribedType = function(describedType) {
-  var options = u.extractDescribedType(Header, describedType.value);
+  var options = {};
+  u.assignFromDescribedType(Header, describedType, options);
+
   return new Header(options);
 };
 
@@ -158,7 +160,9 @@ Properties.prototype.EncodeOrdering = [
 ];
 
 Properties.fromDescribedType = function(describedType) {
-  var options = u.extractDescribedType(Properties, describedType.value);
+  var options = {};
+  u.assignFromDescribedType(Properties, describedType, options);
+
   ['contentType', 'contentEncoding'].forEach(function(option) {
     if (options[option] instanceof AMQPSymbol)
       options[option] = options[option].contents;

--- a/lib/types/message.js
+++ b/lib/types/message.js
@@ -14,8 +14,6 @@ var _ = require('lodash'),
 
     u = require('../utilities');
 
-
-
 /**
  *
  * @param options
@@ -23,11 +21,14 @@ var _ = require('lodash'),
  */
 function Header(options) {
   Header.super_.call(this, Header);
-  this.durable = u.onUndef(options.durable, false);
-  this.priority = u.onUndef(options.priority, 4);
-  this.ttl = options.ttl;
-  this.firstAcquirer = u.onUndef(options.firstAcquirer, false);
-  this.deliveryCount = u.onUndef(options.deliveryCount, 0);
+
+  u.assignDefined(this, options, {
+    durable: u.onUndef(options.durable, false),
+    priority: u.onUndef(options.priority, 4),
+    ttl: options.ttl,
+    firstAcquirer: u.onUndef(options.firstAcquirer, false),
+    deliveryCount: u.onUndef(options.deliveryCount, 0)
+  });
 }
 
 util.inherits(Header, DescribedType);
@@ -37,16 +38,12 @@ Header.prototype.Descriptor = {
   code: new Int64(0x0, 0x70)
 };
 
+Header.prototype.EncodeOrdering = [
+  'durable', 'priority', 'ttl', 'firstAcquirer', 'deliveryCount'
+];
+
 Header.fromDescribedType = function(describedType) {
-  var headerArr = describedType.value;
-  var idx = 0;
-  var options = {
-    durable: u.onUndef(headerArr[idx++], false),
-    priority: u.onUndef(headerArr[idx++], 4),
-    ttl: headerArr[idx++],
-    firstAcquirer: u.onUndef(headerArr[idx++], false),
-    deliveryCount: u.onUndef(headerArr[idx++], 0)
-  };
+  var options = u.extractDescribedType(Header, describedType.value);
   return new Header(options);
 };
 
@@ -58,7 +55,7 @@ Header.prototype.getValue = function() {
     ttl: new ForcedType('uint', self.ttl || null),
     firstAcquirer: self.firstAcquirer,
     deliveryCount: new ForcedType('uint', self.deliveryCount),
-    encodeOrdering: ['durable', 'priority', 'ttl', 'firstAcquirer', 'deliveryCount']
+    encodeOrdering: Header.prototype.EncodeOrdering
   };
 };
 
@@ -129,19 +126,22 @@ module.exports.Annotations = Annotations;
  */
 function Properties(options) {
   Properties.super_.call(this, Properties);
-  this.messageId = options.messageId;
-  this.userId = u.coerce(options.userId, Buffer);
-  this.to = options.to;
-  this.subject = options.subject;
-  this.replyTo = options.replyTo;
-  this.correlationId = options.correlationId;
-  this.contentType = options.contentType;
-  this.contentEncoding = options.contentEncoding;
-  this.absoluteExpiryTime = options.absoluteExpiryTime;
-  this.creationTime = options.creationTime;
-  this.groupId = options.groupId;
-  this.groupSequence = options.groupSequence;
-  this.replyToGroupId = options.replyToGroupId;
+
+  u.assignDefined(this, options, {
+    messageId: options.messageId,
+    userId: u.coerce(options.userId, Buffer),
+    to: options.to,
+    subject: options.subject,
+    replyTo: options.replyTo,
+    correlationId: options.correlationId,
+    contentType: options.contentType,
+    contentEncoding: options.contentEncoding,
+    absoluteExpiryTime: options.absoluteExpiryT,
+    creationTime: options.creationTime,
+    groupId: options.groupId,
+    groupSequence: options.groupSequence,
+    replyToGroupId: options.replyToGroupId,
+  });
 }
 
 util.inherits(Properties, DescribedType);
@@ -151,25 +151,14 @@ Properties.prototype.Descriptor = {
   code: new Int64(0x0, 0x73)
 };
 
-Properties.fromDescribedType = function(describedType) {
-  var propertiesArr = describedType.value;
-  var idx = 0;
-  var options = {
-    messageId: propertiesArr[idx++],
-    userId: propertiesArr[idx++],
-    to: propertiesArr[idx++],
-    subject: propertiesArr[idx++],
-    replyTo: propertiesArr[idx++],
-    correlationId: propertiesArr[idx++],
-    contentType: propertiesArr[idx++],
-    contentEncoding: propertiesArr[idx++],
-    absoluteExpiryTime: propertiesArr[idx++],
-    creationTime: propertiesArr[idx++],
-    groupId: propertiesArr[idx++],
-    groupSequence: propertiesArr[idx++],
-    replyToGroupId: propertiesArr[idx++]
-  };
+Properties.prototype.EncodeOrdering = [
+  'messageId', 'userId', 'to', 'subject', 'replyTo', 'correlationId',
+  'contentType', 'contentEncoding', 'absoluteExpiryTime', 'creationTime',
+  'groupId', 'groupSequence', 'replyToGroupId'
+];
 
+Properties.fromDescribedType = function(describedType) {
+  var options = u.extractDescribedType(Properties, describedType.value);
   ['contentType', 'contentEncoding'].forEach(function(option) {
     if (options[option] instanceof AMQPSymbol)
       options[option] = options[option].contents;
@@ -194,11 +183,7 @@ Properties.prototype.getValue = function() {
     groupId: u.orNull(self.groupId),
     groupSequence: (self.groupSequence === undefined) ? null : new ForcedType('uint', self.groupSequence),
     replyToGroupId: u.orNull(self.replyToGroupId),
-    encodeOrdering: [
-      'messageId', 'userId', 'to', 'subject', 'replyTo', 'correlationId',
-      'contentType', 'contentEncoding', 'absoluteExpiryTime', 'creationTime',
-      'groupId', 'groupSequence', 'replyToGroupId'
-    ]
+    encodeOrdering: Properties.prototype.EncodeOrdering
   };
 };
 
@@ -360,14 +345,14 @@ module.exports.AMQPValue = AMQPValue;
  */
 function Message(contents, body) {
   contents = contents || {};
-  this.header = u.coerce(contents.header, Header);
-  this.deliveryAnnotations =
-    u.coerce(contents.deliveryAnnotations, DeliveryAnnotations);
-  this.annotations = u.coerce(contents.annotations, Annotations);
-  this.properties = u.coerce(contents.properties, Properties);
-  this.applicationProperties =
-    u.coerce(contents.applicationProperties, ApplicationProperties);
-  this.footer = u.coerce(contents.footer, Footer);
+  u.assignDefined(this, contents, {
+    header: u.coerce(contents.header, Header),
+    deliveryAnnotations: u.coerce(contents.deliveryAnnotations, DeliveryAnnotations),
+    annotations: u.coerce(contents.annotations, Annotations),
+    properties: u.coerce(contents.properties, Properties),
+    applicationProperties: u.coerce(contents.applicationProperties, ApplicationProperties),
+    footer: u.coerce(contents.footer, Footer)
+  });
 
   this.body = contents.body || body || [];
 }

--- a/lib/types/source_target.js
+++ b/lib/types/source_target.js
@@ -42,7 +42,8 @@ Source.prototype.EncodeOrdering = [
 ];
 
 Source.fromDescribedType = function(describedType) {
-  var options = u.extractDescribedType(Source, describedType.value, {
+  var options = {};
+  u.assignFromDescribedType(Source, describedType, options, {
     durable: constants.terminusDurability.none,
     expiryPolicy: constants.terminusExpiryPolicy.sessionEnd,
     timeout: 0,
@@ -97,7 +98,8 @@ Target.prototype.EncodeOrdering = [
 ];
 
 Target.fromDescribedType = function(describedType) {
-  var options = u.extractDescribedType(Target, describedType.value, {
+  var options = {};
+  u.assignFromDescribedType(Target, describedType, options, {
     durable: constants.terminusDurability.none,
     expiryPolicy: constants.terminusExpiryPolicy.sessionEnd,
     timeout: 0,

--- a/lib/types/source_target.js
+++ b/lib/types/source_target.js
@@ -35,22 +35,20 @@ Source.prototype.Descriptor = {
   code: new Int64(0x0, 0x28)
 };
 
+Source.prototype.EncodeOrdering = [
+  'address', 'durable', 'expiryPolicy', 'timeout', 'dynamic',
+  'dynamicNodeProperties', 'distributionMode', 'filter', 'defaultOutcome',
+  'outcomes', 'capabilities'
+];
+
 Source.fromDescribedType = function(describedType) {
-  var sourceArr = describedType.value;
-  var idx = 0;
-  var options = {
-    address: u.orNull(sourceArr[idx++]),
-    durable: u.onUndef(sourceArr[idx++], constants.terminusDurability.none),
-    expiryPolicy: u.onUndef(sourceArr[idx++], constants.terminusExpiryPolicy.sessionEnd),
-    timeout: u.onUndef(sourceArr[idx++], 0),
-    dynamic: u.onUndef(sourceArr[idx++], false),
-    dynamicNodeProperties: sourceArr[idx++],
-    distributionMode: sourceArr[idx++],
-    filter: sourceArr[idx++],
-    defaultOutcome: sourceArr[idx++],
-    outcomes: sourceArr[idx++],
-    capabilities: sourceArr[idx++]
-  };
+  var options = u.extractDescribedType(Source, describedType.value, {
+    durable: constants.terminusDurability.none,
+    expiryPolicy: constants.terminusExpiryPolicy.sessionEnd,
+    timeout: 0,
+    dynamic: false
+  });
+
   return new Source(options);
 };
 
@@ -68,8 +66,7 @@ Source.prototype.getValue = function() {
     defaultOutcome: u.orNull(self.defaultOutcome),
     outcomes: u.orNull(self.outcomes),
     capabilities: u.orNull(self.capabilities),
-    encodeOrdering: ['address', 'durable', 'expiryPolicy', 'timeout', 'dynamic', 'dynamicNodeProperties',
-      'distributionMode', 'filter', 'defaultOutcome', 'outcomes', 'capabilities']
+    encodeOrdering: Source.prototype.EncodeOrdering
   };
 };
 
@@ -94,18 +91,20 @@ Target.prototype.Descriptor = {
   code: new Int64(0x0, 0x29)
 };
 
+Target.prototype.EncodeOrdering = [
+  'address', 'durable', 'expiryPolicy', 'timeout', 'dynamic',
+  'dynamicNodeProperties', 'capabilities'
+];
+
 Target.fromDescribedType = function(describedType) {
-  var targetArr = describedType.value;
-  var idx = 0;
-  var options = {
-    address: u.orNull(targetArr[idx++]),
-    durable: u.onUndef(targetArr[idx++], constants.terminusDurability.none),
-    expiryPolicy: u.onUndef(targetArr[idx++], constants.terminusExpiryPolicy.sessionEnd),
-    timeout: u.onUndef(targetArr[idx++], 0),
-    dynamic: u.onUndef(targetArr[idx++], false),
-    dynamicNodeProperties: u.onUndef(targetArr[idx++], {}),
-    capabilities: u.orNull(targetArr[idx++])
-  };
+  var options = u.extractDescribedType(Target, describedType.value, {
+    durable: constants.terminusDurability.none,
+    expiryPolicy: constants.terminusExpiryPolicy.sessionEnd,
+    timeout: 0,
+    dynamic: false,
+    dynamicNodeProperties: {}
+  });
+
   return new Target(options);
 };
 
@@ -119,7 +118,7 @@ Target.prototype.getValue = function() {
     dynamic: u.onUndef(self.dynamic, false),
     dynamicNodeProperties: u.onUndef(self.dynamicNodeProperties, {}),
     capabilities: u.orNull(self.capabilities),
-    encodeOrdering: ['address', 'durable', 'expiryPolicy', 'timeout', 'dynamic', 'dynamicNodeProperties', 'capabilities']
+    encodeOrdering: Target.prototype.EncodeOrdering
   };
 };
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -312,33 +312,20 @@ utilities.assignDefined = function(dest, source, properties) {
 };
 
 /**
- * Extract values for a DescribedType based on that types EncodeOrdering
- */
-utilities.extractDescribedType = function(Type, value, defaults) {
-  defaults = defaults || {};
-
-  var result = {},
-      ordering = Type.prototype.EncodeOrdering;
-  for (var i = 0; i < value.length; i++) {
-    result[ordering[i]] = value[i];
-  }
-
-  if (defaults === undefined)
-    return result;
-  return _.defaults(result, defaults);
-};
-
-/**
  * Extract values for a DescribedType based on that types EncodeOrdering and
  * assigns the values to the passed in instance
+ *
+ * @param Type            the type we are extracting for (for encode ordering purposes)
+ * @param describedType   the described type to extract from
+ * @param dest            the object we are extracting to
+ * @param [defaults]      optional defaults, in the event there is no value in the described type
  */
-utilities.assignDescribedTypeFromPayload = function(Type, instance, payload, defaults) {
-  defaults = defaults || {};
+utilities.assignFromDescribedType = function(Type, describedType, dest, defaults) {
   var ordering = Type.prototype.EncodeOrdering;
-  for (var i = 0; i < payload.value.length; i++) {
-    instance[ordering[i]] = payload.value[i];
+  for (var i = 0; i < describedType.value.length; i++) {
+    dest[ordering[i]] = describedType.value[i];
   }
 
   if (defaults !== undefined)
-    _.defaults(instance, defaults);     // NOTE: this mutates the instance
+    _.defaults(dest, defaults);     // NOTE: this mutates the dest object
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -6,7 +6,8 @@ var _ = require('lodash'),
     constants = require('./constants'),
     errors = require('./errors'),
 
-    uuid = require('uuid');
+    uuid = require('uuid'),
+    utilities = module.exports = {};
 
 
 /**
@@ -20,7 +21,7 @@ function encode(val) {
   return val;
 }
 
-module.exports.encode = encode;
+utilities.encode = encode;
 
 
 /**
@@ -37,17 +38,17 @@ function onUndef(arg1, arg2) {
   return arg1 === undefined ? arg2 : arg1;
 }
 
-module.exports.onUndef = onUndef;
+utilities.onUndef = onUndef;
 
-module.exports.orNull = function(arg1) { return onUndef(arg1, null); };
+utilities.orNull = function(arg1) { return onUndef(arg1, null); };
 
-module.exports.orFalse = function(arg1) { return onUndef(arg1, false); };
+utilities.orFalse = function(arg1) { return onUndef(arg1, false); };
 
 
 /**
  * Convenience methods for operating against DescribedType list payloads.
  */
-module.exports.payload = {
+utilities.payload = {
   assert: function(p, idx, argName) {
     if (p.value === undefined || p.value[idx] === undefined) {
       throw new errors.MalformedPayloadError('Missing required payload field ' + argName + ' at index ' + idx);
@@ -67,7 +68,7 @@ module.exports.payload = {
   }
 };
 
-module.exports.contains = function(arr, elt) {
+utilities.contains = function(arr, elt) {
   var result = false;
   if (arr && arr.length) {
     arr.forEach(function (arrElt) {
@@ -89,7 +90,7 @@ function bufferEquals(lhs, rhs, offset1, offset2, size) {
   return true;
 }
 
-module.exports.bufferEquals = bufferEquals;
+utilities.bufferEquals = bufferEquals;
 
 // Constants
 var addressRegex = new RegExp('^(amqps?)://([^:/]+)(?::([0-9]+))?(/.*)?$');
@@ -145,10 +146,10 @@ function parseAddress(address) {
   throw new Error('Failed to parse ' + address);
 }
 
-module.exports.parseAddress = parseAddress;
+utilities.parseAddress = parseAddress;
 
 // @todo: this "parsing" should be far more rigorous
-module.exports.parseLinkAddress = function(address, policy) {
+utilities.parseLinkAddress = function(address, policy) {
   if (policy && !policy.defaultSubjects) {
     return { name: address };
   }
@@ -196,8 +197,8 @@ function deepMerge() {
   return merged;
 }
 
-module.exports.deepMerge = deepMerge;
-module.exports.deepCopy = deepMerge;
+utilities.deepMerge = deepMerge;
+utilities.deepCopy = deepMerge;
 
 function coerce(val, T) {
   if (val === null || val === undefined) return null;
@@ -211,7 +212,7 @@ function coerce(val, T) {
   return new T(val);
 }
 
-module.exports.coerce = coerce;
+utilities.coerce = coerce;
 
 /**
  * Convenience method to assert that a given options object contains the required arguments.
@@ -229,13 +230,13 @@ function assertArguments(options, argnames) {
   });
 }
 
-module.exports.assertArguments = assertArguments;
+utilities.assertArguments = assertArguments;
 
 function assertArgument(arg, argname) {
   if (arg === undefined) throw new errors.ArgumentError(argname);
 }
 
-module.exports.assertArgument = assertArgument;
+utilities.assertArgument = assertArgument;
 
 function range(start, end) {
   var result = [],
@@ -244,7 +245,7 @@ function range(start, end) {
   return result;
 }
 
-module.exports.generateTimeouts = function(options) {
+utilities.generateTimeouts = function(options) {
   if (options.strategy === 'exponential')
     return range(0, options.retries - 1)
       .map(function(i) { return Math.pow(2, i) * 1000; });
@@ -271,7 +272,7 @@ module.exports.generateTimeouts = function(options) {
  * @param message    either a single message or an array of them
  * @return {Object}
  */
-module.exports.dispositionRange = function(message) {
+utilities.dispositionRange = function(message) {
   var first, last;
   if (_.isArray(message)) {
     first = message[0]._deliveryId;
@@ -293,7 +294,51 @@ module.exports.dispositionRange = function(message) {
  * @param [policyOverrides]   link creation policy overrides
  * @return {String}
  */
-module.exports.linkName = function(address, policyOverrides) {
+utilities.linkName = function(address, policyOverrides) {
   return ((!!policyOverrides && !!policyOverrides.name) ?
     policyOverrides.name : address + '_' + uuid.v4());
+};
+
+
+/**
+ * Assign properties given to dest IFF they are defined in source
+ */
+utilities.assignDefined = function(dest, source, properties) {
+  var propertiesToAssign = _.omit(properties, function(value, key) {
+    return _.isNull(source[key]) || _.isUndefined(source[key]);
+  });
+
+  _.assign(dest, propertiesToAssign);
+};
+
+/**
+ * Extract values for a DescribedType based on that types EncodeOrdering
+ */
+utilities.extractDescribedType = function(Type, value, defaults) {
+  defaults = defaults || {};
+
+  var result = {},
+      ordering = Type.prototype.EncodeOrdering;
+  for (var i = 0; i < value.length; i++) {
+    result[ordering[i]] = value[i];
+  }
+
+  if (defaults === undefined)
+    return result;
+  return _.defaults(result, defaults);
+};
+
+/**
+ * Extract values for a DescribedType based on that types EncodeOrdering and
+ * assigns the values to the passed in instance
+ */
+utilities.assignDescribedTypeFromPayload = function(Type, instance, payload, defaults) {
+  defaults = defaults || {};
+  var ordering = Type.prototype.EncodeOrdering;
+  for (var i = 0; i < payload.value.length; i++) {
+    instance[ordering[i]] = payload.value[i];
+  }
+
+  if (defaults !== undefined)
+    _.defaults(instance, defaults);     // NOTE: this mutates the instance
 };

--- a/test/integration/qpid/client.test.js
+++ b/test/integration/qpid/client.test.js
@@ -139,9 +139,7 @@ describe('Client', function() {
             durable: true,
             priority: 2,
             ttl: 150,
-            firstAcquirer: true,
-            deliveryCount: 0  // this is the default, qpid doesn't seem to do
-                              // anything when I send a value
+            firstAcquirer: true
           }
         }
       },

--- a/test/integration/qpid/sender_link.test.js
+++ b/test/integration/qpid/sender_link.test.js
@@ -42,5 +42,30 @@ describe('SenderLink', function() {
       });
   });
 
+  it('should accept messages as the first parameter', function(done) {
+    return test.client.connect(config.address)
+      .then(function() {
+        return Promise.all([
+          test.client.createReceiver('test.disposition.queue'),
+          test.client.createSender('test.disposition.queue')
+        ]);
+      })
+      .spread(function(receiver, sender) {
+        var receivedCount = 0;
+        receiver.on('message', function(message) {
+          expect(message.body).to.eql({ a: 'message' });
+          expect(message.properties.replyTo).to.eql('somewhere');
+          receivedCount++;
+          if (receivedCount === 2) return done();
+          return sender.send(message);
+        });
+
+        return sender.send({
+          properties: { replyTo: 'somewhere' },
+          body: { a: 'message' }
+        });
+      });
+  });
+
 });
 });


### PR DESCRIPTION
SenderLink.send currently only accepts a signature in the form  of
(body, messageOptions), this patch allows the user to send the
entire formed message as the first parameter.

**NOTE** depends on #155, this PR will be much smaller once that is accepted and this is rebased