### PR TITLE
test(Link): add qpid integration test for link detachment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ branches:
 
 before_script:
   - npm install -g codeclimate-test-reporter
-  - sudo add-apt-repository ppa:mcpierce/qpid-testing -y
+  - sudo add-apt-repository ppa:qpid/testing -y
   - sudo apt-get update -q
   - sudo apt-get install qpidd qpid-tools
   - sudo sh -c 'echo "auth=no" >> /etc/qpid/qpidd.conf'

--- a/lib/session.js
+++ b/lib/session.js
@@ -221,8 +221,8 @@ Session.prototype.createLink = function(linkPolicy) {
 
   var self = this;
   link.on(Link.Detached, function(details) {
-    debug('detached(' + link.name + '): ' + (details ? details.error : 'No details'));
-    if (!link.shouldReattach()) self._removeLink(self);
+    debug('detached(' + this.name + '): ' + (details ? details.error : 'No details'));
+    if (!this.shouldReattach()) self._removeLink(this);
   });
 
   link.on(Link.ErrorReceived, function(err) {
@@ -238,15 +238,15 @@ Session.prototype.createLink = function(linkPolicy) {
 };
 
 ///
-/// Remove a link from the sender
+/// Remove a link from the session
 ///
 Session.prototype._removeLink = function(link) {
   delete this._allocatedHandles[link.handle];
   if (link instanceof SenderLink) {
-    debug('Removing sender link ' + link.name);
+    debug('removing sender link ' + link.name);
     delete this._senderLinks[link.name];
   } else {
-    debug('Removing receiver link ' + link.name);
+    debug('removing receiver link ' + link.name);
     delete this._receiverLinks[link.name];
   }
 };

--- a/test/integration/qpid/client.test.js
+++ b/test/integration/qpid/client.test.js
@@ -81,6 +81,16 @@ describe('Client', function() {
       });
   });
 
+  it('should be able to detach a link', function() {
+    return test.client.connect(config.address)
+      .then(function() {
+        return test.client.createSender(config.defaultLink);
+      })
+      .then(function(sender) {
+        return sender.detach();
+      });
+  });
+
   describe('Messages', function() {
     [
       {


### PR DESCRIPTION
Previously this was not possible because of a bug in qpidd 0.32,
however I've updated the qpid ppa to include version 0.34 and we
can now include this integration test