### PR TITLE
refactor(Message): reduce needless complexity of body parsing

### DIFF
--- a/lib/types/message.js
+++ b/lib/types/message.js
@@ -358,7 +358,7 @@ function Message(contents, body) {
     footer: u.coerce(contents.footer, Footer)
   });
 
-  this.body = contents.body || body || [];
+  this.body = contents.body || body;
 }
 
 Message.prototype.encode = function(codec, buf) {
@@ -367,24 +367,14 @@ Message.prototype.encode = function(codec, buf) {
   if (this.annotations) codec.encode(this.annotations, buf);
   if (this.properties) codec.encode(this.properties, buf);
   if (this.applicationProperties) codec.encode(this.applicationProperties, buf);
-  if (this.body.length > 1) {
-    if (this.body instanceof Buffer) {
-      codec.encode(new Data(this.body), buf);
-    } else if (typeof this.body === 'string') {
-      codec.encode(new AMQPValue(this.body), buf);
-    } else {
-      codec.encode(new AMQPSequence(this.body), buf);
-    }
+  if (this.body instanceof Buffer) {
+    codec.encode(new Data(this.body), buf);
+  } else if (Array.isArray(this.body)) {
+    codec.encode(new AMQPSequence(this.body), buf);
   } else {
-    if (Array.isArray(this.body)) {
-      if (this.body[0] instanceof Buffer)
-        codec.encode(new Data(this.body[0]), buf);
-      else
-        codec.encode(new AMQPValue(this.body[0]), buf);
-    } else {
-      codec.encode(new AMQPValue(this.body), buf);
-    }
+    codec.encode(new AMQPValue(this.body), buf);
   }
+
   if (this.footer) codec.encode(this.footer, buf);
 };
 

--- a/test/unit/test_frame_encodings.js
+++ b/test/unit/test_frame_encodings.js
@@ -192,7 +192,7 @@ describe('TransferFrame', function() {
     });
     transfer.channel = 1;
     transfer.message = new M.Message();
-    transfer.message.body.push(new ForcedType('uint', 10));
+    transfer.message.body = new ForcedType('uint', 10);
     var actual = tu.convertFrameToBuffer(transfer);
     var payloadSize = 12;
     var listSize = 1 + 2 + 2 + 3 + 5 + 1 + 1 + 2 + 1 + 1 + 1 + 1;


### PR DESCRIPTION
  - skip checks for body.size and Array.isArray when encoding the
    message body
  - set message body to content.body || body, no default to []