### PR TITLE
DOS attack when server requires SASL and client doesnt give creds

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -391,7 +391,7 @@ Connection.prototype._tryReceiveHeader = function(header) {
         this.connSM.validVersion();
         this.connSM.sendOpen();
       } else {
-        var msg = 'Invalid AMQP version received: '
+        var msg = 'Invalid AMQP version received: ';
         if (u.bufferEquals(serverVersion, constants.saslVersion)) {
           msg = 'Credentials Expected - SASL version received: ';
         }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -391,7 +391,11 @@ Connection.prototype._tryReceiveHeader = function(header) {
         this.connSM.validVersion();
         this.connSM.sendOpen();
       } else {
-        this.emit(Connection.ErrorReceived, 'Invalid AMQP version received: ' + serverVersion.toString('hex'));
+        var msg = 'Invalid AMQP version received: '
+        if (u.bufferEquals(serverVersion, constants.saslVersion)) {
+          msg = 'Credentials Expected - SASL version received: ';
+        }
+        this.emit(Connection.ErrorReceived, msg + serverVersion.toString('hex'));
         this.connSM.invalidVersion();
       }
       this._receivedHeader = true;


### PR DESCRIPTION
my local QPID server requires SASL auth and i forgot to put my credentials in the connection string. the resulting infinite loop essentially performed a DOS attack on my server until it crashed.

here is the code:
```javascript
var AMQPClient = require('amqp10');
var client = new AMQPClient();
client.connect('amqp://localhost/myqueue')
  .then(function() {
    client.receive(function (rx_err, message) {
      // ... check for errors ...
      console.log('Rx message: ');
      console.log(JSON.parse(message.body));
    });
    return client.send(JSON.stringify({ key: "Value" }));
  })
  .catch(function(err) {
    console.log("error: " + err);
  });
```

```
node app.js
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Connecting to amqp://localhost/myqueue
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Connecting to localhost:5672 via straight-up sockets
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from DISCONNECTED to START due to connect
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Sending Header 414d515000010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from START to HDR_SENT due to connected
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Rx: 414d515003010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Server AMQP Version: 414d515003010000 vs 414d515000010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Connection error:  Invalid AMQP version received: 414d515003010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Disconnected
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Connecting to amqp://localhost/myqueue
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Connecting to localhost:5672 via straight-up sockets
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from DISCONNECTED to START due to connect
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from HDR_SENT to DISCONNECTING due to invalidVersion
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Disconnected
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Connecting to amqp://localhost/myqueue
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Connecting to localhost:5672 via straight-up sockets
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from DISCONNECTED to START due to connect
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from DISCONNECTING to DISCONNECTED due to terminated
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Sending Header 414d515000010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from START to HDR_SENT due to connected
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Sending Header 414d515000010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from START to HDR_SENT due to connected
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Rx: 414d515003010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Server AMQP Version: 414d515003010000 vs 414d515000010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Connection error:  Invalid AMQP version received: 414d515003010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Disconnected
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Connecting to amqp://localhost/myqueue
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Connecting to localhost:5672 via straight-up sockets
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from DISCONNECTED to START due to connect
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from HDR_SENT to DISCONNECTING due to invalidVersion
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Disconnected
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Connecting to amqp://localhost/myqueue
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Connecting to localhost:5672 via straight-up sockets
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from DISCONNECTED to START due to connect
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Transitioning from DISCONNECTING to DISCONNECTED due to terminated
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Rx: 414d515003010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-Connection Server AMQP Version: 414d515003010000 vs 414d515000010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Connection error:  Invalid AMQP version received: 414d515003010000
Tue, 29 Sep 2015 21:44:09 GMT amqp10-client Disconnected
...
(node) warning: possible EventEmitter memory leak detected. 11 Session.Mapped listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at AMQPClient.addListener (events.js:179:15)
    at AMQPClient._attemptReconnection (/Users/danlangford/Code/node-amqp/node_modules/amqp10/lib/amqp_client.js:626:8)
    at Connection.<anonymous> (/Users/danlangford/Code/node-amqp/node_modules/amqp10/lib/amqp_client.js:211:12)
    at Connection.emit (events.js:107:17)
    at Connection._terminate (/Users/danlangford/Code/node-amqp/node_modules/amqp10/lib/connection.js:551:8)
    at Object.Connection.stateMachine.HDR_SENT.invalidVersion (/Users/danlangford/Code/node-amqp/node_modules/amqp10/lib/connection.js:228:14)
    at Object.event [as invalidVersion] (/Users/danlangford/Code/node-amqp/node_modules/amqp10/node_modules/stately.js/Stately.js:206:67)
    at Connection._tryReceiveHeader (/Users/danlangford/Code/node-amqp/node_modules/amqp10/lib/connection.js:391:21)
    at Connection._receiveAny (/Users/danlangford/Code/node-amqp/node_modules/amqp10/lib/connection.js:431:21)
    at Connection._receiveData (/Users/danlangford/Code/node-amqp/node_modules/amqp10/lib/connection.js:363:8)
...
Tue, 29 Sep 2015 21:54:37 GMT amqp10-client Connecting to amqp://localhost/myqueue
Tue, 29 Sep 2015 21:54:37 GMT amqp10-Connection Connecting to localhost:5672 via straight-up sockets
Tue, 29 Sep 2015 21:54:37 GMT amqp10-Connection Transitioning from DISCONNECTED to START due to connect
Tue, 29 Sep 2015 21:54:37 GMT amqp10-Connection Transitioning from START to DISCONNECTED due to error
Tue, 29 Sep 2015 21:54:37 GMT amqp10-Connection Error from socket: Error: connect ECONNREFUSED
Tue, 29 Sep 2015 21:54:37 GMT amqp10-client Connection error:  { [Error: connect ECONNREFUSED]
  code: 'ECONNREFUSED',
  errno: 'ECONNREFUSED',
  syscall: 'connect' }
Tue, 29 Sep 2015 21:54:37 GMT amqp10-client Disconnected
Tue, 29 Sep 2015 21:54:37 GMT amqp10-client Connecting to amqp://localhost/myqueue
Tue, 29 Sep 2015 21:54:37 GMT amqp10-Connection Connecting to localhost:5672 via straight-up sockets
Tue, 29 Sep 2015 21:54:37 GMT amqp10-Connection Transitioning from DISCONNECTED to START due to connect
Tue, 29 Sep 2015 21:54:37 GMT amqp10-Connection Transitioning from START to DISCONNECTED due to error
Tue, 29 Sep 2015 21:54:37 GMT amqp10-Connection Error from socket: Error: connect ECONNREFUSED
Tue, 29 Sep 2015 21:54:37 GMT amqp10-client Connection error:  { [Error: connect ECONNREFUSED]
  code: 'ECONNREFUSED',
  errno: 'ECONNREFUSED',
  syscall: 'connect' }
Tue, 29 Sep 2015 21:54:37 GMT amqp10-client Disconnected
```

while the server did this:
```
...
[Broker] MNG-1004 : JMX Management Ready
[Broker] BRK-1004 : Qpid Broker Ready

########################################################################
#
# Unhandled Exception java.lang.OutOfMemoryError: unable to create new native thread in Thread IoNetworkAcceptor - 0.0.0.0/0.0.0.0:5672
#
# Exiting
#
########################################################################
java.lang.OutOfMemoryError: unable to create new native thread
...
```

and crashed.

(dont use those timestamps to assume length of time, i was piecing together logs )

i traced the beginning of the confusion down to here:
```javascript
if (this.sasl) {
      this.sasl.headerReceived(serverVersion);
    } else {
      debug('Server AMQP Version: ' + serverVersion.toString('hex') + ' vs ' + header.toString('hex'));
      if (this.connSM.getMachineState() === 'START') {
        this.connSM.headerReceived();
      }

      if (utils.bufferEquals(serverVersion, constants.amqpVersion)) {
        this.connSM.validVersion();
        this.connSM.sendOpen();
      } else {
        this.emit(Connection.ErrorReceived, 'Invalid AMQP version received: ' + serverVersion.toString('hex'));
        this.connSM.invalidVersion();
      }
      this._receivedHeader = true;
    }
```

you see the logic says `if (this.sasl)` and `this.sasl` was only created if the url had a user in it like `amqps://user:pass@localhost/myqueue`. `this.sasl` does not exist so we fall down to the the `if (utils.bufferEquals(serverVersion, constants.amqpVersion)) ` which is false because the server sent a SASL version number. server responded `AMQP3100` we are testing against `AMQP0100`

ultimately the infinite loop is here
```javascript
    if (self._shouldReconnect()) {
      self._attemptReconnection();
    }
```

and i didnt see clearly the correct way to disable reconnects. 

i added a user name and password and im good to go HOWEVER im just grateful that i did not start by pointing it at a broker that is actually used. :-P

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/165)
<!-- Reviewable:end -->
