### PR TITLE
refactor(AMQPClient): reset link state on clearConnectionState

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -309,6 +309,8 @@ AMQPClient.prototype._clearConnectionState = function(saveReconnectDetails) {
   if (!saveReconnectDetails) {
     this._reconnect = null;
   }
+
+  if (this._session) this._session._resetLinkState();
 };
 
 // Helper methods for mocking in tests.

--- a/lib/session.js
+++ b/lib/session.js
@@ -465,4 +465,17 @@ Session.prototype._handleDisposition = function(frame) {
   this.emit(Session.DispositionReceived, disposition);
 };
 
+/**
+ * INTERNAL
+ * Resets the state of all known links for this session.
+ */
+Session.prototype._resetLinkState = function() {
+  var forceDetachLink = function(l) {
+    if (l.state() === 'attached' || l.state() === 'attaching') l.forceDetach();
+  };
+
+  _.values(this._senderLinks).forEach(forceDetachLink);
+  _.values(this._receiverLinks).forEach(forceDetachLink);
+};
+
 module.exports = Session;


### PR DESCRIPTION
This is primarily important for reconnect scenarios where links
have already been created. In those cases, the links otherwise would
be left with an "attached" or "attaching" state and would therefore
never have been reconnected.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/166)
<!-- Reviewable:end -->
