### PR TITLE
Adding AMQPSymbol to index, wrapping AMQPErrors into exposed type

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -355,7 +355,7 @@ Connection.prototype._nextChannel = function() {
 
 Connection.prototype._processError = function(err) {
   debug('Error from socket: ' + err);
-  this.emit(Connection.ErrorReceived, err);
+  this.emit(Connection.ErrorReceived, errors.wrapProtocolError(err));
   this._terminate(err);
 };
 
@@ -393,7 +393,7 @@ Connection.prototype._tryReceiveHeader = function(header) {
         if (u.bufferEquals(serverVersion, constants.saslVersion)) {
           msg = 'Credentials Expected - SASL version received: ';
         }
-        this.emit(Connection.ErrorReceived, msg + serverVersion.toString('hex'));
+        this.emit(Connection.ErrorReceived, new errors.VersionError(msg + serverVersion.toString('hex')));
         this.connSM.invalidVersion();
       }
       this._receivedHeader = true;
@@ -515,7 +515,7 @@ Connection.prototype._processCloseFrame = function(frame) {
   this.connSM.closeReceived();
   this.connSM.sendClose();
   if (frame.error) {
-    this.emit(Connection.ErrorReceived, frame.error);
+    this.emit(Connection.ErrorReceived, errors.wrapProtocolError(frame.error));
   }
 };
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var util = require('util');
+var util = require('util'),
+  AMQPError = require('./types/amqp_error');
 var errors = module.exports = {};
 
 /**
@@ -18,6 +19,21 @@ errors.BaseError = function() {
     Error.captureStackTrace(this, this.constructor);
 };
 util.inherits(errors.BaseError, Error);
+
+errors.ProtocolError = function(amqpError) {
+  errors.BaseError.call(this, amqpError.condition.contents + ':' + (amqpError.description || 'no description'));
+  this.name = 'AmqpProtocolError';
+
+  this.condition = amqpError.condition.contents;
+  this.description = amqpError.description;
+  this.errorInfo = amqpError.errorInfo;
+};
+util.inherits(errors.ProtocolError, errors.BaseError);
+
+errors.wrapProtocolError = function(err) {
+  if (err instanceof AMQPError) return new errors.ProtocolError(err);
+  return err;
+};
 
 /**
  * AMQP Header is malformed.
@@ -150,3 +166,16 @@ errors.DisconnectedError = function(msg) {
   this.name = 'AmqpDisconnectedError';
 };
 util.inherits(errors.DisconnectedError, errors.ConnectionError);
+
+/**
+ * AMQP Version error
+ *
+ * @param msg
+ * @extends BaseError
+ * @constructor
+ */
+errors.VersionError = function(msg) {
+  errors.BaseError.call(this, msg);
+  this.name = 'AmqpVersionError';
+};
+util.inherits(errors.VersionError, errors.BaseError);

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ module.exports = {
       return u.deepMerge(newPolicy, base || DefaultPolicy);
     }
   },
+  Symbol: require('./types/amqp_symbol'),
 
   /**
    * translator, which allows you to translate from node-amqp-encoder'd

--- a/lib/link.js
+++ b/lib/link.js
@@ -3,6 +3,7 @@
 var EventEmitter = require('events').EventEmitter,
     Promise = require('bluebird'),
     util = require('util'),
+    errors = require('./errors'),
 
     StateMachine = require('stately.js'),
 
@@ -172,7 +173,7 @@ Link.prototype._sendDetach = function() {
 
 Link.prototype._detached = function(frame) {
   if (frame && frame.error) {
-    this.emit(Link.ErrorReceived, frame.error);
+    this.emit(Link.ErrorReceived, errors.wrapProtocolError(frame.error));
   }
 
   if (this.remoteHandle !== undefined) {
@@ -180,7 +181,7 @@ Link.prototype._detached = function(frame) {
     this.remoteHandle = undefined;
   }
 
-  this.emit(Link.Detached, { closed: frame.closed, error: frame.error });
+  this.emit(Link.Detached, { closed: frame.closed, error: errors.wrapProtocolError(frame.error) });
   this._resolveAttachPromises(frame.error ? frame.error : 'link closed');
 
   var self = this;

--- a/lib/session.js
+++ b/lib/session.js
@@ -224,7 +224,7 @@ Session.prototype.createLink = function(linkPolicy) {
   });
 
   link.on(Link.ErrorReceived, function(err) {
-    self.emit(Session.ErrorReceived , err);
+    self.emit(Session.ErrorReceived, err);
   });
 
   if (this.mapped) {
@@ -425,7 +425,7 @@ Session.prototype._transferReceived = function(frame) {
 
 Session.prototype._endReceived = function(frame) {
   if (frame.error) {
-    this.emit(Session.ErrorReceived, frame.error);
+    this.emit(Session.ErrorReceived, errors.wrapProtocolError(frame.error));
   }
 };
 

--- a/test/unit/test_connection.js
+++ b/test/unit/test_connection.js
@@ -195,7 +195,7 @@ describe('Connection', function() {
         process.nextTick(function() {
           expect(events).to.have.length(3);
           expect(events[0][0]).to.eql(Connection.ErrorReceived);
-          expect(events[0][1]).to.include('Invalid AMQP version');
+          expect(events[0][1].message).to.include('Invalid AMQP version');
           expect(events[1]).to.eql(Connection.Disconnected);
           expect(events[2]).to.eql(Connection.Disconnected);
           done();
@@ -237,7 +237,7 @@ describe('Connection', function() {
         process.nextTick(function() {
           expect(events).to.have.length(3);
           expect(events[0][0]).to.eql(Connection.ErrorReceived);
-          expect(events[0][1]).to.include('Credentials Expected');
+          expect(events[0][1].message).to.include('Credentials Expected');
           expect(events[1]).to.eql(Connection.Disconnected);
           expect(events[2]).to.eql(Connection.Disconnected);
           done();

--- a/test/unit/test_session.js
+++ b/test/unit/test_session.js
@@ -3,6 +3,7 @@
 var expect = require('chai').expect,
 
     constants = require('../../lib/constants'),
+    errors = require('../../lib/errors'),
     u = require('../../lib/utilities'),
     tu = require('./testing_utils'),
     _ = require('lodash'),
@@ -224,7 +225,7 @@ describe('Session', function() {
           var opts = u.deepMerge({ attach: { name: 'test', source: src(), target: tgt() } }, DefaultPolicy.senderLink);
           var link = session.createLink(opts);
           link.on('errorReceived', function(err) {
-            expect(err).to.eql(new AMQPError(AMQPError.LinkDetachForced, 'test', ''));
+            expect(err).to.eql(errors.wrapProtocolError(new AMQPError(AMQPError.LinkDetachForced, 'test', '')));
           });
 
           link.linkSM.bind(tu.assertTransitions(expected.link, function(transitions) {


### PR DESCRIPTION
Note: I crack the condition AMQPSymbol, since we only want the contents.

Also, adding a VersionError since we were dumping a raw string out as an error there.