### PR TITLE
add support for AMQP over websockets for Azure IoT Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If you find any issues, please report them via GitHub.
 ## Implementation Notes ##
 
 +   Using node's built-in net/tls classes for communicating with the server.
++   Using [nodejs-websocket](https://github.com/sitegui/nodejs-websocket) for Azure IoT Hub support of AMQP over WebSockets.
 
 +   Data from the server is written to a buffer-list based on [Rod Vagg's BL](https://github.com/rvagg/bl).
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -23,7 +23,7 @@ var EventEmitter = require('events').EventEmitter,
     HeartbeatFrame = require('./frames/heartbeat_frame'),
     OpenFrame = require('./frames/open_frame');
 
-    
+
 
 /**
  * Connection states, from AMQP 1.0 spec:
@@ -539,7 +539,8 @@ Connection.prototype._connect = function(address, sasl) {
       self.client.connect(address);
       break;
     default:
-    // TODO: Error
+      // this should never happen because it's checked in default_policy.js (in parseAddress)
+      throw new Error('invalid protocol: ' + address.protocol);
   }
   
   self.client.on('connect', function() {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -2,9 +2,11 @@
 
 var EventEmitter = require('events').EventEmitter,
     fs = require('fs'),
-    net = require('net'),
-    tls = require('tls'),
     util = require('util'),
+    
+    WebSocketClient = require('./sockets/websocketclient.js'),
+    BasicSocketClient = require('./sockets/basicsocketclient.js'),
+    TlsSocketClient = require('./sockets/tlssocketclient.js'),
 
     debug = require('debug')('amqp10:connection'),
     BufferList = require('bl'),
@@ -21,7 +23,7 @@ var EventEmitter = require('events').EventEmitter,
     HeartbeatFrame = require('./frames/heartbeat_frame'),
     OpenFrame = require('./frames/open_frame');
 
-
+    
 
 /**
  * Connection states, from AMQP 1.0 spec:
@@ -523,25 +525,36 @@ Connection.prototype._connect = function(address, sasl) {
   this.address = address;
   var self = this;
   self.dataHandler = self._receiveHeader;
-  var isSSL = address.protocol === 'amqps';
-  if (isSSL) {
-    var sslOptions = self._sslOptions || {};
-    sslOptions.port = self.address.port;
-    sslOptions.host = self.address.host;
-    self.client = tls.connect(sslOptions);
-    debug('Connecting to ' + self.address.host + ':' + self.address.port + ' via TLS');
-  } else {
-    self.client = net.connect({ port: self.address.port, host: self.address.host });
-    debug('Connecting to ' + self.address.host + ':' + self.address.port + ' via straight-up sockets');
+  switch (address.protocol) {
+    case 'wss':
+      self.client = new WebSocketClient();
+      self.client.connect(address);
+      break;
+    case 'amqps':
+      self.client = new TlsSocketClient();
+      self.client.connect(address, self._sslOptions);
+      break;
+    case 'amqp':
+      self.client = new BasicSocketClient();
+      self.client.connect(address);
+      break;
+    default:
+    // TODO: Error
   }
   
-  self.client.on(isSSL ? 'secureConnect' : 'connect', function() {
+  self.client.on('connect', function() {
     self.connSM.connected(sasl);
-  }).on('data', function(buf) {
+  });
+  
+  self.client.on('data', function(buf) {
     self._receiveData(buf);
-  }).on('error', function(err) {
+  });
+  
+  self.client.on('error', function(err) {
     self.connSM.error(err);
-  }).on('end', function() {
+  });
+  
+  self.client.on('end', function() {
     debug('on(end)');
     self.connSM.terminated();
   });

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -13,6 +13,7 @@ function amqpify(arr) {
 var Constants = {
   defaultPort: 5672,
   defaultTlsPort: 5671,
+  defauttWssPort: 443,
   minMaxFrameSize: 512,
   defaultMaxFrameSize: 4294967295,
   defaultChannelMax: 65535,

--- a/lib/policies/default_policy.js
+++ b/lib/policies/default_policy.js
@@ -110,9 +110,10 @@ module.exports = {
       host: parsedAddress.hostname,
       path: parsedAddress.path || '/',
       protocol: parsedAddress.protocol.slice(0, -1).toLowerCase() || 'amqp',
+      href: parsedAddress.href
     };
 
-    if (result.protocol !== 'amqp' && result.protocol !== 'amqps')
+    if (result.protocol !== 'amqp' && result.protocol !== 'amqps' && result.protocol !== 'wss')
       throw new Error('invalid protocol: ' + result.protocol);
 
     if (!!parsedAddress.port) {
@@ -121,6 +122,7 @@ module.exports = {
       switch (result.protocol.toLowerCase()) {
         case 'amqp': result.port = constants.defaultPort; break;
         case 'amqps': result.port = constants.defaultTlsPort; break;
+        case 'wss': result.port = constants.defauttWssPort; break;
       }
     }
 

--- a/lib/sockets/basicsocketclient.js
+++ b/lib/sockets/basicsocketclient.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var util = require("util");
+var EventEmitter = require('events');
+var net = require('net');
+var debug = require('debug')('amqp10:connection:basicsocketclient');
+
+function BasicSocketClient() {
+	EventEmitter.call(this);
+	this._client = null;
+}
+
+util.inherits(BasicSocketClient, EventEmitter);
+
+BasicSocketClient.prototype.connect = function (address) {
+		debug('Connecting to ' + address.host + ':' + address.port + ' via straight-up sockets');
+		this._client = net.connect({ port: address.port, host: address.host });
+		
+		this._client.on('connect', function() { this.emit('connect'); }.bind(this));
+		this._client.on('data', function(data) { this.emit('data', data); }.bind(this));
+		this._client.on('error', function(err) { this.emit('error', err); }.bind(this));
+		this._client.on('end', function() { this.emit('end'); }.bind(this));
+};
+
+BasicSocketClient.prototype.write = function (data) {
+	if(this._client) {
+		this._client.write(data);
+	} else {
+		throw new Error('Socket not connected');
+	}
+};
+
+BasicSocketClient.prototype.end = function() {
+	if (this._client) {
+		this._client.end();
+	} else {
+		throw new Error('Socket not connected');
+	}
+};
+
+BasicSocketClient.prototype.destroy = function() {
+	if (this._client) {
+		this._client.destroy();
+		this._client = null;
+		this.removeAllListeners();
+	} else {
+		throw new Error('Socket not connected');
+	}
+};
+
+module.exports = BasicSocketClient;

--- a/lib/sockets/tlssocketclient.js
+++ b/lib/sockets/tlssocketclient.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var util = require("util");
+var EventEmitter = require('events');
+var tls = require('tls');
+var debug = require('debug')('amqp10:connection:tlssocketclient');
+
+function TlsSocketClient() {
+	EventEmitter.call(this);
+	this._client = null;
+}
+
+util.inherits(TlsSocketClient, EventEmitter);
+
+TlsSocketClient.prototype.connect = function (address, sslOpts) {
+	var sslOptions = sslOpts || {};
+	sslOptions.port = address.port;
+	sslOptions.host = address.host;
+	this._client = tls.connect(sslOptions);
+	debug('Connecting to ' + address.host + ':' + address.port + ' via TLS');
+	
+	this._client.on('secureConnect', function() { this.emit('connect'); }.bind(this));
+	this._client.on('data', function(data) { this.emit('data', data); }.bind(this));
+	this._client.on('error', function(err) { this.emit('error', err); }.bind(this));
+	this._client.on('end', function() { this.emit('end'); }.bind(this));
+};
+
+TlsSocketClient.prototype.write = function (data) {
+	if(this._client) {
+		this._client.write(data);
+	} else {
+		throw new Error('Socket not connected');
+	}
+};
+
+TlsSocketClient.prototype.end = function() {
+	if (this._client) {
+		this._client.end();
+	} else {
+		throw new Error('Socket not connected');
+	}
+};
+
+TlsSocketClient.prototype.destroy = function() {
+	if (this._client) {
+		this._client.destroy();
+		this._client = null;
+		this.removeAllListeners();
+	} else {
+		throw new Error('Socket not connected');
+	}
+};
+
+module.exports = TlsSocketClient;

--- a/lib/sockets/websocketclient.js
+++ b/lib/sockets/websocketclient.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var util = require("util");
+var EventEmitter = require('events');
+var ws = require('nodejs-websocket');
+var debug = require('debug')('amqp10:connection:websocketclient');
+
+function WebSocketClient () {
+	EventEmitter.call(this);
+	this._client = null;
+}
+
+util.inherits(WebSocketClient, EventEmitter);
+
+/** TODO
+ *  - verify frame size for binary transfers.
+ *  - double check if we need the text transfers.
+ *  - verify resources are properly destroyed.
+ */ 
+
+WebSocketClient.prototype.connect = function (address) {
+	this._client = ws.connect(address.href, { extraHeaders: { 'Sec-Websocket-Protocol': 'AMQPWSB10' } }, function() {
+		debug('Websocket connection initiated');
+	});
+	
+	this._client.on('connect', function () {
+		this.emit('connect');    
+	}.bind(this));
+	
+	this._client.on('binary', function (inStream) {
+		// Empty buffer for collecting binary data
+		var data = new Buffer(0);
+		// Read chunks of binary data and add to the buffer
+		inStream.on("readable", function () {
+			var newData = inStream.read();
+			if (newData) {
+				data = Buffer.concat([data, newData], data.length+newData.length);
+			}
+		});
+		
+		inStream.on("end", function () {
+			debug("Received " + data.length + " bytes of binary data over websocket connection");
+			this.emit('data', data);      
+		}.bind(this));
+	}.bind(this));
+	
+	this._client.on('error', function (err) {
+		this.emit('error', err);      	
+	}.bind(this));
+	
+	this._client.on('text', function (text) {
+		debug("Received text data over websocket connection");
+		this.emit('data', text);
+	}.bind(this));
+	
+	this._client.on('close', function (code, reason) {
+		debug('Websocket connection closed with code: ' + code + " (" + reason + ")");
+		this.emit('end');   
+	}.bind(this));
+};
+
+WebSocketClient.prototype.write = function (data) {
+	if(this._client) {
+		this._client.sendBinary(data);
+	} else {
+		throw new Error('Socket not connected');
+	}
+};
+
+WebSocketClient.prototype.end = function() {
+	if (this._client) {
+		this._client.close();
+	} else {
+		throw new Error('Socket not connected');
+	}
+};
+
+WebSocketClient.prototype.destroy = function() {
+	if (this._client) {
+		this._client = null;
+		this.removeAllListeners();
+	} else {
+		throw new Error('Socket not connected');
+	}
+};
+
+module.exports = WebSocketClient;

--- a/package.json
+++ b/package.json
@@ -7,13 +7,14 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "buffer-builder": "^0.2.0",
     "bl": "^1.0.0",
     "bluebird": "^3.0.0",
+    "buffer-builder": "^0.2.0",
     "debug": "^2.0.0",
     "lodash": "^3.3.0",
     "node-amqp-encoder": "^0.0.2",
     "node-int64": "^0.4.0",
+    "nodejs-websocket": "^1.4.1",
     "stately.js": "^1.2.0",
     "uuid": "^2.0.1"
   },

--- a/test/unit/address.test.js
+++ b/test/unit/address.test.js
@@ -13,7 +13,8 @@ describe('Address Parsing', function() {
         address: 'amqp://127.0.0.1',
         expected: {
           protocol: 'amqp', host: '127.0.0.1', port: 5672, path: '/',
-          rootUri: 'amqp://127.0.0.1:5672'
+          rootUri: 'amqp://127.0.0.1:5672',
+          href: 'amqp://127.0.0.1'
         }
       },
       {
@@ -21,7 +22,8 @@ describe('Address Parsing', function() {
         address: 'amqps://localhost',
         expected: {
           protocol: 'amqps', host: 'localhost', port: 5671, path: '/',
-          rootUri: 'amqps://localhost:5671'
+          rootUri: 'amqps://localhost:5671',
+          href: 'amqps://localhost'
         }
       },
       {
@@ -29,7 +31,8 @@ describe('Address Parsing', function() {
         address: 'amqp://localhost:1234',
         expected: {
           protocol: 'amqp', host: 'localhost', port: 1234, path: '/',
-          rootUri: 'amqp://localhost:1234'
+          rootUri: 'amqp://localhost:1234',
+          href: 'amqp://localhost:1234'
         }
       },
       {
@@ -38,7 +41,8 @@ describe('Address Parsing', function() {
         expected: {
           protocol: 'amqps', host: 'mq.myhost.com', port: 1235,
           path: '/myroute?with=arguments&multiple=arguments',
-          rootUri: 'amqps://mq.myhost.com:1235'
+          rootUri: 'amqps://mq.myhost.com:1235',
+          href: 'amqps://mq.myhost.com:1235/myroute?with=arguments&multiple=arguments'
         }
       },
       {
@@ -46,7 +50,8 @@ describe('Address Parsing', function() {
         address: 'amqp://10.42.1.193:8118/testqueue',
         expected: {
           protocol: 'amqp', host: '10.42.1.193', port: 8118, path: '/testqueue',
-          rootUri: 'amqp://10.42.1.193:8118'
+          rootUri: 'amqp://10.42.1.193:8118',
+          href: 'amqp://10.42.1.193:8118/testqueue'
         }
       },
       {
@@ -55,7 +60,8 @@ describe('Address Parsing', function() {
         expected: {
           protocol: 'amqp', host: 'my.amqp.server', port: 5672, path: '/',
           user: 'username', pass: 'password',
-          rootUri: 'amqp://username:password@my.amqp.server:5672'
+          rootUri: 'amqp://username:password@my.amqp.server:5672',
+          href: 'amqp://username:password@my.amqp.server'
         }
       },
       {
@@ -64,7 +70,8 @@ describe('Address Parsing', function() {
         expected: {
           protocol: 'amqps', host: '192.168.1.1', port: 1234, path: '/myroute',
           user: 'username', pass: 'password',
-          rootUri: 'amqps://username:password@192.168.1.1:1234'
+          rootUri: 'amqps://username:password@192.168.1.1:1234',
+          href: 'amqps://username:password@192.168.1.1:1234/myroute'
         }
       }
     ].forEach(function(testCase) {
@@ -97,7 +104,8 @@ describe('Address Parsing', function() {
         protocol: 'amqps',
         rootUri: 'amqps://username:password@192.168.1.1:1234',
         user: 'username',
-        vhost: 'some-vhost'
+        vhost: 'some-vhost',
+        href: 'amqps://username:password@192.168.1.1:1234/some-vhost/topic/and/more'
       });
     });
   });
@@ -112,7 +120,8 @@ describe('Address Parsing', function() {
         port: 1234,
         protocol: 'amqps',
         rootUri: 'amqps://username:password@192.168.1.1:1234',
-        user: 'username'
+        user: 'username',
+        href: 'amqps://username:password@192.168.1.1:1234/topic://mytopic'
       });
     });
 


### PR DESCRIPTION
Here's a first stab at separating the transport layer from connection.js (meaning extracting the dependencies to net and tls in specific files) and adding websocket support to enable amqp over websockets for Azure IoT Hub

the websocket library used has the benefit of being entirely written in javascript, unlike other popular ones. the good thing about this change is that it makes it easier to change or add transport layers by just creating another client in the socket folder, and then figuring out in connection.js how to decide whether we should be using plain sockets, secure sockets (tls) or websockets.

I have run unit tests but not integration tests - I might need a little help doing this :) 