### PR TITLE
refactor(long): directly embed encoding for ulong/long

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -433,16 +433,17 @@ registerType('ulong', {
     encoding(0x44, constantValue(0)),
     encoding(0x80, {
       encoder: function(val, bufb) {
-        if (val instanceof Int64) {
-          bufb.appendBuffer(val.toBuffer(true));
-        } else {
-          if (val < 0xFFFFFFFF) {
-            bufb.appendUInt32BE(0x0);
-            bufb.appendUInt32BE(val);
-          } else {
-            bufb.appendBuffer((new Int64(val)).toBuffer());
-          }
+        if (val instanceof Int64) return bufb.appendBuffer(val.toBuffer(true));
+        if (val instanceof Buffer) return bufb.appendBuffer(val);
+        if (typeof val !== 'number' || !(val instanceof Number)) val = Number(val);
+        if (!Number.isFinite(val)) {
+          throw new errors.EncodingError(val, 'invalid number');
         }
+
+        var high = val / MAX_UINT;
+        var low = val % MAX_UINT;
+        bufb.appendUInt32BE(high);
+        bufb.appendUInt32BE(low);
       },
       decoder: function(buf) {
         var high = buf.readUInt32BE(0);
@@ -484,18 +485,30 @@ registerType('long', {
     encoding(0x55, bufferOperations('Int8')),
     encoding(0x81, {
       encoder: function(val, bufb) {
-        if (val instanceof Int64) {
-          bufb.appendBuffer(val.toBuffer(true));
-        } else if (typeof val === 'number') {
-          var absval = Math.abs(val);
-          if (absval < 0xFFFFFFFF) {
-            bufb.appendUInt32BE(val < 0 ? 0xFFFFFFFF : 0x0);
-            bufb.appendUInt32BE(val < 0 ? (0xFFFFFFFF - absval + 1) : absval);
-          } else {
-            bufb.appendBuffer((new Int64(val)).toBuffer());
-          }
+        if (val instanceof Int64) return bufb.appendBuffer(val.toBuffer(true));
+        if (val instanceof Buffer) return bufb.appendBuffer(val);
+        if (typeof val !== 'number' || !(val instanceof Number)) val = Number(val);
+        if (!Number.isFinite(val)) {
+          throw new errors.EncodingError(val, 'invalid number');
+        }
+
+        var abs = Math.abs(val);
+        var high = abs / MAX_UINT;
+        var low = abs % MAX_UINT;
+        if (val > 0) {
+          bufb.appendInt32BE(high);
+          bufb.appendInt32BE(low);
         } else {
-          throw new errors.EncodingError(val, 'Invalid encoding type for 64-bit value');
+          // need to write to a buffer in order to calculate the 2s complement
+          var data = new Buffer(8), carry = 1;
+          for (var i = 7; i >= 0; i--) {
+            var value = ((low & 0xff) ^ 0xff) + carry;
+            data[i] = value & 0xff;
+            low = (i === 4) ? high : low >>> 8;
+            carry = value >> 8;
+          }
+
+          bufb.appendBuffer(data);
         }
       },
       decoder: function(buf) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -497,14 +497,15 @@ registerType('long', {
         var low = abs % MAX_UINT;
         if (val > 0) {
           bufb.appendInt32BE(high);
-          bufb.appendInt32BE(low);
+          bufb.appendUInt32BE(low);
         } else {
           // need to write to a buffer in order to calculate the 2s complement
-          var data = new Buffer(8), carry = 1;
+          var data = new Buffer(8),
+              carry = 1, current = low;
           for (var i = 7; i >= 0; i--) {
-            var value = ((low & 0xff) ^ 0xff) + carry;
+            var value = ((current & 0xff) ^ 0xff) + carry;
             data[i] = value & 0xff;
-            low = (i === 4) ? high : low >>> 8;
+            current = (i === 4) ? high : current >>> 8;
             carry = value >> 8;
           }
 

--- a/test/unit/test_types.js
+++ b/test/unit/test_types.js
@@ -87,6 +87,23 @@ describe('Types', function() {
 
         });
 
+        it('should encode/decode the same as node-int64', function() {
+          var tests = [
+            { type: 'long', code: 0x81, value: 5000 },
+            { type: 'ulong', code: 0x80, value: 5000 }
+          ];
+
+          tests.forEach(function(test) {
+            var buffer = new BufferBuilder();
+            codec.encode(new ForcedType(test.type, test.value), buffer);
+            var int64 = new Int64(buffer.get().slice(1));
+            expect(int64.toNumber()).to.equal(test.value);
+            var fromInt64Buffer = Buffer.concat([new Buffer([test.code]), int64.toBuffer()]);
+            var fromInt64 = codec.decode(fromInt64Buffer);
+            expect(fromInt64[0]).to.equal(test.value);
+          });
+        });
+
         var vbin32Buffer = [];
         var str32Utf8String;
         var sym32String;


### PR DESCRIPTION
The first step towards dropping our dependency on node-int64. 

@noodlefrenzy while you're at it, you might want to take a look at the code I already submitted for ulong/long encoding. It should have gone into review, but I think I was a bit over-eager there (it's right next to the code in this PR, so it shouldn't be hard to seek out). 