### PR TITLE
refactor(errors): support encoding of AMQPErrors

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,5 +1,4 @@
 'use strict';
-
 var EventEmitter = require('events').EventEmitter,
     fs = require('fs'),
     util = require('util'),
@@ -13,7 +12,7 @@ var EventEmitter = require('events').EventEmitter,
     frames = require('./frames'),
     u = require('./utilities'),
 
-    AMQPError = require('./types/amqp_error'),
+    ErrorCondition = require('./types/error_condition'),
     TransportProvider = require('./transport');
 
 
@@ -252,7 +251,7 @@ function Connection(connectPolicy) {
         return this.CLOSE_RCVD;
       },
       invalidOptions: function() {
-        self._sendCloseFrame(AMQPError.ConnectionForced, 'Invalid options');
+        self._sendCloseFrame(ErrorCondition.ConnectionForced, 'Invalid options');
         return this.CLOSE_SENT;
       },
       sendClose: function() {

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,5 +1,4 @@
 'use strict';
-
 var Builder = require('buffer-builder'),
     Int64 = require('node-int64'),
     uuid = require('uuid'),
@@ -38,6 +37,8 @@ function registerType(name, options) {
     types[encoding.code].encode = encoding.encoder;
   });
 }
+
+types.registerType = registerType;
 
 /**
  * Encoder methods are used for all examples of that type and are expected to encode to the proper

--- a/lib/types/amqp_error.js
+++ b/lib/types/amqp_error.js
@@ -1,44 +1,34 @@
 'use strict';
-var types = require('../types');
+var ErrorCondition = require('./error_condition'),
+    ForcedType = require('./forced_type'),
+    types = require('../types'),
+    errors = require('../errors'),
+    u = require('../utilities');
+
 var AMQPError = types.defineComposite({
   name: 'error', code: 0x1d,
   fields: [
-    { name: 'condition', type: 'symbol', mandatory: 'true' },
+    { name: 'condition', type: 'symbol', requires: errorCondition, mandatory: true },
     { name: 'description', type: 'string' },
     { name: 'info', type: 'fields' }
   ]
 });
 
-AMQPError.InternalError = 'amqp:internal-error';
-AMQPError.NotFound = 'amqp:not-found';
-AMQPError.UnauthorizedAccess = 'amqp:unauthorized-access';
-AMQPError.DecodeError = 'amqp:decode-error';
-AMQPError.ResourceLimitExceeded = 'amqp:resource-limit-exceeded';
-AMQPError.NotAllowed = 'amqp:not-allowed';
-AMQPError.InvalidField = 'amqp:invalid-field';
-AMQPError.NotImplemented = 'amqp:not-implemented';
-AMQPError.ResourceLocked = 'amqp:resource-locked';
-AMQPError.PreconditionFailed = 'amqp:precondition-failed';
-AMQPError.ResourceDeleted = 'amqp:resource-deleted';
-AMQPError.IllegalState = 'amqp:illegal-state';
-AMQPError.FrameSizeTooSmall = 'amqp:frame-size-too-small';
+function errorCondition(value) {
+  if (!ErrorCondition.hasOwnProperty(value))
+    throw new errors.EncodingError(value, 'invalid error condition');
 
-// Connection errors
-AMQPError.ConnectionForced = 'amqp:connection:forced';
-AMQPError.ConnectionFramingError = 'amqp:connection:framing-error';
-AMQPError.ConnectionRedirect = 'amqp:connection:redirect';
+  return ErrorCondition.hasOwnProperty(ErrorCondition[value]) ?
+    new ForcedType('symbol', ErrorCondition[ErrorCondition[value]]) :
+    new ForcedType('symbol', ErrorCondition[value]);
+}
 
-// Session errors
-AMQPError.SessionWindowViolation = 'amqp:session:window-violation';
-AMQPError.SessionErrantLink = 'amqp:session:errant-link';
-AMQPError.SessionHandleInUse = 'amqp:session:handle-in-use';
-AMQPError.SessionUnattachedHandle = 'amqp:session:unattached-handle';
-
-// Link errors
-AMQPError.LinkDetachForced = 'amqp:link:detach-forced';
-AMQPError.LinkTransferLimitExceeded = 'amqp:link:transfer-limit-exceeded';
-AMQPError.LinkMessageSizeExceeded = 'amqp:link:message-size-exceeded';
-AMQPError.LinkRedirect = 'amqp:link:redirect';
-AMQPError.LinkStolen = 'amqp:link:stolen';
+types.registerType('error', {
+  encoder: function(value, bufb, codec) {
+    var error = u.isObject(value) ?
+      new AMQPError(value) : new AMQPError({ condition: value });
+    codec.encode(error, bufb);
+  }
+});
 
 module.exports = AMQPError;

--- a/lib/types/composite_type.js
+++ b/lib/types/composite_type.js
@@ -23,11 +23,9 @@ function wrapField(field, value) {
     return null;
   }
 
-  if (field.type === '*') {
-    if (field.hasOwnProperty('requires'))
-       return (value instanceof field.requires) ? value : new field.requires(value);
-    return value;
-  }
+  if (field.hasOwnProperty('requires'))
+    return (value instanceof field.requires) ? value : new field.requires(value);
+  if (field.type === '*') return value;
 
   if (Array.isArray(value)) {
     if (field.multiple === false) {

--- a/lib/types/error_condition.js
+++ b/lib/types/error_condition.js
@@ -1,0 +1,44 @@
+'use strict';
+var u = require('../utilities'),
+    ErrorCondition = module.exports = {};
+
+function defineErrorCondition(symbol) {
+  var stringReference = symbol.replace(/amqp:/, '');
+  var enumReference = u.camelCase(stringReference);
+  enumReference = enumReference.charAt(0).toUpperCase() + enumReference.slice(1);
+  ErrorCondition[stringReference] = symbol;
+  ErrorCondition[enumReference] = stringReference;
+}
+
+// shared
+defineErrorCondition('amqp:internal-error');
+defineErrorCondition('amqp:not-found');
+defineErrorCondition('amqp:unauthorized-access');
+defineErrorCondition('amqp:decode-error');
+defineErrorCondition('amqp:resource-limit-exceeded');
+defineErrorCondition('amqp:not-allowed');
+defineErrorCondition('amqp:invalid-field');
+defineErrorCondition('amqp:not-implemented');
+defineErrorCondition('amqp:resource-locked');
+defineErrorCondition('amqp:precondition-failed');
+defineErrorCondition('amqp:resource-deleted');
+defineErrorCondition('amqp:illegal-state');
+defineErrorCondition('amqp:frame-size-too-small');
+
+// connection
+defineErrorCondition('amqp:connection:forced');
+defineErrorCondition('amqp:connection:framing-error');
+defineErrorCondition('amqp:connection:redirect');
+
+// session
+defineErrorCondition('amqp:session:window-violation');
+defineErrorCondition('amqp:session:errant-link');
+defineErrorCondition('amqp:session:handle-in-use');
+defineErrorCondition('amqp:session:unattached-handle');
+
+// link
+defineErrorCondition('amqp:link:detach-forced');
+defineErrorCondition('amqp:link:transfer-limit-exceeded');
+defineErrorCondition('amqp:link:message-size-exceeded');
+defineErrorCondition('amqp:link:redirect');
+defineErrorCondition('amqp:link:stolen');

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -249,12 +249,15 @@ utilities.linkName = function(address, policyOverrides) {
 
 utilities.camelCase = function(name) {
   return name.toLowerCase()
-    .replace(/[-_]+/g, ' ')
+    .replace(/[-_:]+/g, ' ')
     .replace(/[^\w\s]/g, '')
     .replace(/ (.)/g, function($1) { return $1.toUpperCase(); })
     .replace(/ /g, '' );
 };
 
+
+// NOTE: this is to get around cyclic dependencies, obviously not the right
+//       place for this to live
 var AMQPError = require('./types/amqp_error');
 utilities.wrapProtocolError = function(err) {
   if (err instanceof AMQPError)

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -11,6 +11,7 @@ var _ = require('lodash'),
 
     DefaultPolicy = require('../../lib/policies/default_policy'),
     AMQPError = require('../../lib/types/amqp_error'),
+    ErrorCondition = require('../../lib/types/error_condition'),
     m = require('../../lib/types/message'),
     DeliveryState = require('../../lib/types/delivery_state'),
 
@@ -54,7 +55,7 @@ describe('Client', function() {
           handleMax: 4294967295
         }),
         new frames.CloseFrame({
-          error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+          error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
         })
       ]);
 
@@ -90,7 +91,7 @@ describe('Client', function() {
           return txFrame;
         },
         new frames.CloseFrame({
-          error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+          error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
         })
       ]);
 
@@ -156,7 +157,7 @@ describe('Client', function() {
           }
         ],
         new frames.CloseFrame({
-          error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+          error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
         })
       ]);
 
@@ -204,7 +205,7 @@ describe('Client', function() {
           state: new DeliveryState.Accepted()
         }),
         new frames.CloseFrame({
-          error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+          error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
         })
       ]);
 
@@ -276,7 +277,7 @@ describe('Client', function() {
           handleMax: 4294967295
         }),
         new frames.CloseFrame({
-          error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+          error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
         })
       ]);
 
@@ -313,7 +314,7 @@ describe('Client', function() {
           handleMax: 4294967295
         }),
         new frames.CloseFrame({
-          error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+          error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
         })
       ]);
 

--- a/test/unit/policies/qpid_java.test.js
+++ b/test/unit/policies/qpid_java.test.js
@@ -6,6 +6,7 @@ var amqp = require('../../../lib'),
     constants = require('../../../lib/constants'),
     frames = require('../../../lib/frames'),
     AMQPError = require('../../../lib/types/amqp_error'),
+    ErrorCondition = require('../../../lib/types/error_condition'),
 
     test = require('../test-fixture');
 
@@ -63,7 +64,7 @@ describe('QpidJava Policy', function() {
           handleMax: 4294967295
         }),
         new frames.CloseFrame({ error:
-          new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+          new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
         })
       ]);
 

--- a/test/unit/test_connection.js
+++ b/test/unit/test_connection.js
@@ -6,6 +6,7 @@ var expect = require('chai').expect,
     DefaultPolicy = require('../../lib/policies/default_policy'),
     MockServer = require('./mock_amqp'),
     AMQPError = require('../../lib/types/amqp_error'),
+    ErrorCondition = require('../../lib/types/error_condition'),
     Connection = require('../../lib/connection'),
     tu = require('./testing_utils');
 
@@ -104,7 +105,7 @@ describe('Connection', function() {
         new frames.OpenFrame(DefaultPolicy.connect.options),
         [ true,
           new frames.CloseFrame({
-            error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+            error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
           })
         ]
       ]);
@@ -130,7 +131,7 @@ describe('Connection', function() {
         new frames.OpenFrame(DefaultPolicy.connect.options),
         [ true,
           new frames.CloseFrame({
-            error: new AMQPError({ condition: AMQPError.ConnectionForced, decription: 'test' })
+            error: new AMQPError({ condition: ErrorCondition.ConnectionForced, decription: 'test' })
           })
         ]
       ]);
@@ -175,7 +176,7 @@ describe('Connection', function() {
         new frames.OpenFrame(DefaultPolicy.connect.options),
         [ true,
           new frames.CloseFrame({
-            error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+            error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
           })
         ]
       ]);
@@ -221,7 +222,7 @@ describe('Connection', function() {
         new frames.OpenFrame(DefaultPolicy.connect.options),
         [ true,
           new frames.CloseFrame({
-            error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+            error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
           })
         ]
       ]);

--- a/test/unit/test_sasl.js
+++ b/test/unit/test_sasl.js
@@ -8,6 +8,7 @@ var builder = require('buffer-builder'),
 
     MockServer = require('./mock_amqp'),
     AMQPError = require('../../lib/types/amqp_error'),
+    ErrorCondition = require('../../lib/types/error_condition'),
 
     Connection = require('../../lib/connection'),
     Sasl = require('../../lib/sasl'),
@@ -51,7 +52,7 @@ describe('Sasl', function() {
         new frames.OpenFrame(DefaultPolicy.connect.options),
         [ true,
           new frames.CloseFrame({
-            error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+            error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
           })
         ]
       ]);

--- a/test/unit/test_session.js
+++ b/test/unit/test_session.js
@@ -4,7 +4,6 @@ var expect = require('chai').expect,
 
     constants = require('../../lib/constants'),
     frames = require('../../lib/frames'),
-//    errors = require('../../lib/errors'),
     u = require('../../lib/utilities'),
     tu = require('./testing_utils'),
     _ = require('lodash'),
@@ -15,6 +14,7 @@ var expect = require('chai').expect,
     Session = require('../../lib/session'),
 
     AMQPError = require('../../lib/types/amqp_error'),
+    ErrorCondition = require('../../lib/types/error_condition'),
     MockServer = require('./mock_amqp');
 
 DefaultPolicy.connect.options.containerId = 'test';
@@ -84,7 +84,7 @@ describe('Session', function() {
         new MockBeginFrame({ remoteChannel: 1 }, 5),
         [ true,
           new MockEndFrame({
-            error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test'})
+            error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test'})
           }, 5)
         ],
         [ true, new frames.CloseFrame() ]
@@ -138,7 +138,7 @@ describe('Session', function() {
         new MockBeginFrame({ remoteChannel: 1 }, 5),
         [ true,
           new MockEndFrame({
-            error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+            error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
           }, 5)
         ],
         [ true, new frames.CloseFrame() ]
@@ -190,12 +190,12 @@ describe('Session', function() {
         [ true,
           new MockDetachFrame({
             handle: 3,
-            error: new AMQPError({ condition: AMQPError.LinkDetachForced, description: 'test' })
+            error: new AMQPError({ condition: ErrorCondition.LinkDetachForced, description: 'test' })
           }, 5)
         ],
         [ true,
           new MockEndFrame({
-            error: new AMQPError({ condition: AMQPError.ConnectionForced, description: 'test' })
+            error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
           }, 5)
         ],
         [ true, new frames.CloseFrame() ]
@@ -235,7 +235,7 @@ describe('Session', function() {
           var opts = u.deepMerge({ attach: { name: 'test', source: src(), target: tgt() } }, DefaultPolicy.senderLink);
           var link = session.createLink(opts);
           link.on('errorReceived', function(err) {
-//            expect(err).to.eql(errors.wrapProtocolError(new AMQPError(AMQPError.LinkDetachForced, 'test', '')));
+//            expect(err).to.eql(errors.wrapProtocolError(new AMQPError(ErrorCondition.LinkDetachForced, 'test', '')));
           });
 
           link.linkSM.bind(tu.assertTransitions(expected.link, function(transitions) {

--- a/test/unit/types/errors.test.js
+++ b/test/unit/types/errors.test.js
@@ -1,0 +1,88 @@
+'use strict';
+var AMQPError = require('../../../lib/types/amqp_error'),
+    ErrorCondition = require('../../../lib/types/error_condition'),
+    frames = require('../../../lib/frames'),
+    builder = require('buffer-builder'),
+    tu = require('../testing_utils'),
+    expect = require('chai').expect;
+
+describe('Types(Errors)', function() {
+  var expected = tu.buildBuffer([
+    0x00, 0x00, 0x00, 0x30,
+    0x02, 0x00, 0x00, 0x00,
+    0x00, 0x53, 0x18,
+      0xc0, 0x23, 0x01,
+      0x00, 0x53, 0x1d,
+        0xc0, 0x1d, 0x03,
+        0xa3, 0x13, builder.prototype.appendString, 'amqp:internal-error',  // condition
+        0xa1, 0x04, builder.prototype.appendString, 'test',                 // description
+        0x40                                                                // info
+  ]);
+
+  var expectedWithoutDescription = tu.buildBuffer([
+    0x00, 0x00, 0x00, 0x2b,
+    0x02, 0x00, 0x00, 0x00,
+    0x00, 0x53, 0x18,
+      0xc0, 0x1e, 0x01,
+      0x00, 0x53, 0x1d,
+        0xc0, 0x18, 0x03,
+        0xa3, 0x13, builder.prototype.appendString, 'amqp:internal-error',  // condition
+        0x40,                                                               // description
+        0x40                                                                // info
+  ]);
+
+  it('should encode using direct type, enum error condition', function() {
+    var close = new frames.CloseFrame({
+      error: new AMQPError({ condition: ErrorCondition.InternalError, description: 'test' })
+    });
+
+    var actual = tu.convertFrameToBuffer(close);
+    expect(expected).to.eql(actual);
+  });
+
+  it('should encode using direct type, string error condition', function() {
+    var close = new frames.CloseFrame({
+      error: new AMQPError({ condition: 'internal-error', description: 'test' })
+    });
+
+    var actual = tu.convertFrameToBuffer(close);
+    expect(expected).to.eql(actual);
+  });
+
+  it('should encode using object, enum error condition', function() {
+    var close = new frames.CloseFrame({
+      error: { condition: ErrorCondition.InternalError, description: 'test' }
+    });
+
+    var actual = tu.convertFrameToBuffer(close);
+    expect(expected).to.eql(actual);
+  });
+
+  it('should encode using object type, string error condition', function() {
+    var close = new frames.CloseFrame({
+      error: { condition: 'internal-error', description: 'test' }
+    });
+
+    var actual = tu.convertFrameToBuffer(close);
+    expect(expected).to.eql(actual);
+  });
+
+  it('should encode using just an enum', function() {
+    var close = new frames.CloseFrame({
+      error: ErrorCondition.InternalError
+    });
+
+    var actual = tu.convertFrameToBuffer(close);
+    expect(expectedWithoutDescription).to.eql(actual);
+  });
+
+  it('should encode using just a string', function() {
+    var close = new frames.CloseFrame({
+      error: 'internal-error'
+    });
+
+    var actual = tu.convertFrameToBuffer(close);
+    expect(expectedWithoutDescription).to.eql(actual);
+  });
+
+});


### PR DESCRIPTION
Not too much craziness going on here, but definitely enough to
warrant comment:

  - error conditions have all been moved to the ErrorCondition enum
    module. They are enumerated both by legacy enum format
    (e.g. InternalError, or LinkRedirect), but also now by names
    used in the spec ('internal-error', 'link:redirect'). This
    opens us up to the possibility of users simply needing to use
    a string in order to send the required error.

  - errors can be specified by full use of the AMQPError type
    internally (it is not exported), as well as by a plain object
    (e.g. { condition: 'internal-error', description: 'test' }), or
    just a string (for the mandatory condition field).

  - any unknown errors will throw an EncodingError

  - tests for all of this are baked in