### PR TITLE
Split ServiceBus Queue tests by process version

### DIFF
--- a/lib/receiver_link.js
+++ b/lib/receiver_link.js
@@ -30,6 +30,7 @@ ReceiverLink.prototype.addCredits = function(credits, flowOptions) {
   this.totalCredits += credits;
   this.session._sessionParams.incomingWindow += credits;
 
+  debug('addCredits ('+this.name+'): New values: link('+this.linkCredit+'), session('+this.session._sessionParams.incomingWindow+')');
   // send flow frame
   flowOptions = flowOptions || {};
   var options = u.defaults(flowOptions, {
@@ -191,7 +192,7 @@ ReceiverLink.prototype._messageReceived = function(transferFrame) {
 };
 
 ReceiverLink.prototype._dispositionReceived = function(details) {
-  debug('not yet processing "receiver" disposition frames');
+  debug('not yet processing "receiver" disposition frames: ', details);
 };
 
 module.exports = ReceiverLink;

--- a/test/integration/servicebus/queues/client.test.js
+++ b/test/integration/servicebus/queues/client.test.js
@@ -19,8 +19,7 @@ describe('Queues', function() {
   });
 
   it('should connect, send, and receive a message', function(done) {
-    expect(config.serviceBusHost, 'Required env vars not found in ' + Object.keys(process.env)).to.exist;
-
+    expect(config.address).to.exist;
     var msgVal = uuid.v4();
     test.client = new AMQPClient(Policy.ServiceBusQueue);
     return test.client.connect(config.address)
@@ -45,8 +44,7 @@ describe('Queues', function() {
   });
 
   it('should throttle based on link credit policy', function(done) {
-    expect(config.serviceBusHost, 'Required env vars not found in ' + Object.keys(process.env)).to.exist;
-
+    expect(config.address).to.exist;
     test.client = new AMQPClient(Policy.Utils.RenewOnSettle(1, 1, Policy.ServiceBusQueue));
     var count = 0;
     var acked = false;
@@ -83,8 +81,7 @@ describe('Queues', function() {
   });
 
   it('should allow you to reject messages and continue to receive subsequent', function(done) {
-    expect(config.serviceBusHost, 'Required env vars not found in ' + Object.keys(process.env)).to.exist;
-
+    expect(config.address).to.exist;
     var msgVal1 = uuid.v4();
     var msgVal2 = uuid.v4();
     test.client = new AMQPClient(Policy.merge({ receiverLink: { attach: { receiverSettleMode: 1 }}}, Policy.ServiceBusQueue));

--- a/test/integration/servicebus/queues/client.test.js
+++ b/test/integration/servicebus/queues/client.test.js
@@ -11,6 +11,7 @@ describe('ServiceBus', function() {
 describe('Queues', function() {
   beforeEach(function() {
     if (!!test.client) test.client = undefined;
+    expect(config.address).to.exist;
   });
 
   afterEach(function() {
@@ -19,7 +20,6 @@ describe('Queues', function() {
   });
 
   it('should connect, send, and receive a message', function(done) {
-    expect(config.address).to.exist;
     var msgVal = uuid.v4();
     test.client = new AMQPClient(Policy.ServiceBusQueue);
     return test.client.connect(config.address)
@@ -44,7 +44,6 @@ describe('Queues', function() {
   });
 
   it('should throttle based on link credit policy', function(done) {
-    expect(config.address).to.exist;
     test.client = new AMQPClient(Policy.Utils.RenewOnSettle(1, 1, Policy.ServiceBusQueue));
     var count = 0;
     var acked = false;
@@ -81,7 +80,6 @@ describe('Queues', function() {
   });
 
   it('should allow you to reject messages and continue to receive subsequent', function(done) {
-    expect(config.address).to.exist;
     var msgVal1 = uuid.v4();
     var msgVal2 = uuid.v4();
     test.client = new AMQPClient(Policy.merge({ receiverLink: { attach: { receiverSettleMode: 1 }}}, Policy.ServiceBusQueue));

--- a/test/integration/servicebus/queues/config.js
+++ b/test/integration/servicebus/queues/config.js
@@ -1,9 +1,15 @@
 'use strict';
-module.exports = {
-  protocol: 'amqps',
-  serviceBusHost: process.env.ServiceBusNamespace,
-  defaultLink: process.env.ServiceBusQueueName,
-  sasKeyName: process.env.ServiceBusQueueKeyName,
-  sasKey: process.env.ServiceBusQueueKey,
-  address: 'amqps' + '://' + encodeURIComponent(process.env.ServiceBusQueueKeyName) + ':' + encodeURIComponent(process.env.ServiceBusQueueKey) + '@' + process.env.ServiceBusNamespace + '.servicebus.windows.net'
-};
+var tu = require('../../../testing_utils.js');
+
+module.exports = tu.populateConfig({
+  serviceBusHost: 'ServiceBusNamespace',
+  defaultLink: 'ServiceBusQueueNames',
+  sasKeyName: 'ServiceBusQueueKeyNames',
+  sasKey: 'ServiceBusQueueKeys'
+}, function(config) {
+  config.protocol = 'amqps';
+  config.address = config.protocol + '://' +
+    encodeURIComponent(config.sasKeyName) + ':' + encodeURIComponent(config.sasKey) +
+      '@' + config.serviceBusHost + '.servicebus.windows.net';
+  return config;
+});

--- a/test/testing_utils.js
+++ b/test/testing_utils.js
@@ -9,7 +9,10 @@ var Builder = require('buffer-builder'),
 
 function populateConfig(configKeyMap, cb) {
   var processVersion = process.version;
-  expect(process.env).to.contain.all.keys(['ValidProcessVersions'].concat(Object.keys(configKeyMap).map(function(x) { return configKeyMap[x]; })));
+  expect(process.env.ValidProcessVersions, 'Missing env ValidProcessVersions').to.exist;
+  Object.keys(configKeyMap).forEach(function (k) {
+    expect(process.env[configKeyMap[k]], 'Missing env ' + k).to.exist;
+  });
   var versions = process.env.ValidProcessVersions.split('|').map(function(x) { return new RegExp(x, 'i'); });
   var idx = 0;
   for (var i = 0; i < versions.length; ++i) {

--- a/test/unit/frames.test.js
+++ b/test/unit/frames.test.js
@@ -3,7 +3,7 @@
 var frames = require('../../lib/frames'),
     builder = require('buffer-builder'),
     constants = require('../../lib/constants'),
-    tu = require('./testing_utils'),
+    tu = require('./../testing_utils'),
     expect = require('chai').expect,
 
     DeliveryState = require('../../lib/types/delivery_state'),

--- a/test/unit/mock_amqp.js
+++ b/test/unit/mock_amqp.js
@@ -5,7 +5,7 @@ var BufferList = require('bl'),
     net = require('net'),
     expect = require('chai').expect,
     frames = require('../../lib/frames'),
-    tu = require('./testing_utils');
+    tu = require('./../testing_utils');
 
 var MockServer = function(port) {
   this.server = null;

--- a/test/unit/mocks/server.js
+++ b/test/unit/mocks/server.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
     expect = require('chai').expect,
     debug = require('debug')('amqp10:mock:server'),
     frames = require('../../../lib/frames'),
-    tu = require('../testing_utils');
+    tu = require('../../testing_utils');
 
 function MockServer(options) {
   this._server = null;

--- a/test/unit/test_codec.js
+++ b/test/unit/test_codec.js
@@ -9,7 +9,7 @@ var Int64 = require('node-int64'),
     DescribedType = require('../../lib/types/described_type'),
     ForcedType = require('../../lib/types/forced_type'),
 
-    tu = require('./testing_utils');
+    tu = require('./../testing_utils');
 
 var buildBuffer = tu.buildBuffer;
 var newBuffer = tu.newBuffer;

--- a/test/unit/test_connection.js
+++ b/test/unit/test_connection.js
@@ -8,7 +8,7 @@ var expect = require('chai').expect,
     AMQPError = require('../../lib/types/amqp_error'),
     ErrorCondition = require('../../lib/types/error_condition'),
     Connection = require('../../lib/connection'),
-    tu = require('./testing_utils');
+    tu = require('./../testing_utils');
 
 DefaultPolicy.connect.options.containerId = 'test';
 

--- a/test/unit/test_sasl.js
+++ b/test/unit/test_sasl.js
@@ -13,7 +13,7 @@ var builder = require('buffer-builder'),
     Connection = require('../../lib/connection'),
     Sasl = require('../../lib/sasl'),
 
-    tu = require('./testing_utils');
+    tu = require('./../testing_utils');
 
 DefaultPolicy.connect.options.containerId = 'test';
 

--- a/test/unit/test_session.js
+++ b/test/unit/test_session.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect,
     constants = require('../../lib/constants'),
     frames = require('../../lib/frames'),
     u = require('../../lib/utilities'),
-    tu = require('./testing_utils'),
+    tu = require('./../testing_utils'),
     _ = require('lodash'),
 
     DefaultPolicy = require('../../lib/policies/default_policy'),

--- a/test/unit/test_types.js
+++ b/test/unit/test_types.js
@@ -10,7 +10,7 @@ var expect = require('chai').expect,
     AMQPArray = require('../../lib/types/amqp_composites').Array,
 
     errors = require('../../lib/errors'),
-    tu = require('./testing_utils');
+    tu = require('./../testing_utils');
 
 var buf = tu.buildBuffer;
 

--- a/test/unit/test_utilities.js
+++ b/test/unit/test_utilities.js
@@ -1,7 +1,7 @@
 'use strict';
 var expect = require('chai').expect,
     u = require('../../lib/utilities'),
-    tu = require('./testing_utils');
+    tu = require('./../testing_utils');
 
 describe('Utilities', function() {
   describe('#contains()', function() {

--- a/test/unit/types/errors.test.js
+++ b/test/unit/types/errors.test.js
@@ -3,7 +3,7 @@ var AMQPError = require('../../../lib/types/amqp_error'),
     ErrorCondition = require('../../../lib/types/error_condition'),
     frames = require('../../../lib/frames'),
     builder = require('buffer-builder'),
-    tu = require('../testing_utils'),
+    tu = require('../../testing_utils'),
     expect = require('chai').expect;
 
 describe('Types(Errors)', function() {

--- a/test/unit/types/message_sections.test.js
+++ b/test/unit/types/message_sections.test.js
@@ -1,7 +1,7 @@
 'use strict';
 var Builder = require('buffer-builder'),
     m = require('../../../lib/types/message'),
-    tu = require('../testing_utils'),
+    tu = require('../../testing_utils'),
     expect = require('chai').expect;
 
 describe('Message Sections', function() {


### PR DESCRIPTION
… to avoid races/collisions in parallel travis runs.

Oh, and add a little extra debug information for some dispo frame (lack of) processing.