### PR TITLE
Allow sslOptions to be passed directly to the transport.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -160,17 +160,20 @@ function Connection(connectPolicy) {
   };
   this._sslOptions = null;
   if (options.sslOptions) {
-    this._sslOptions = {};
+    this._sslOptions = options.sslOptions;
+
     if (options.sslOptions.keyFile) {
       this._sslOptions.key = fs.readFileSync(options.sslOptions.keyFile);
+      delete this._sslOptions.keyFile;
     }
     if (options.sslOptions.certFile) {
       this._sslOptions.cert = fs.readFileSync(options.sslOptions.certFile);
+      delete this._sslOptions.certFile;
     }
     if (options.sslOptions.caFile) {
       this._sslOptions.ca = fs.readFileSync(options.sslOptions.caFile);
+      delete this._sslOptions.caFile;
     }
-    this._sslOptions.rejectUnauthorized = options.sslOptions.rejectUnauthorized;
   }
 
   this._lastOutgoing = null; // To track whether heartbeat frame required.


### PR DESCRIPTION
Small modification to connection.js to allow any SSL options to be passed directly to the transport, while keeping the possibility to specify certFile/caFile/keyFile and have amqp10 read the file for the user