### PR TITLE
Fix a typo in utilities.wrapProtocolError

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -270,6 +270,6 @@ utilities.camelCase = function(name) {
 var AMQPError = require('./types/amqp_error');
 utilities.wrapProtocolError = function(err) {
   if (err instanceof AMQPError)
-    return new errors.ProtocolError(err.condition, err.description, err.errorInfo);
+    return new errors.ProtocolError(err.condition, err.description, err.info);
   return err;
 };


### PR DESCRIPTION
`err.errorInfo` seem to be `undefined` when `wrapProtocolError` is called, and it looks like what used to be `errorInfo` is now `info`.

FYI the iothub-explorer tool in the Azure IoT SDK relies on testing the content of this `info` property to detect amqp redirections and subsequently connect to the proper event hubs endpoint when monitoring events sent by devices, so this blocks our migration to v3.x.x