### PR TITLE
change merge to deepCopy in Session.prototype.begin() to create a new…

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -173,7 +173,7 @@ Session.ErrorReceived = 'errorReceived';
 Session.DispositionReceived = 'disposition';
 
 Session.prototype.begin = function(sessionPolicy) {
-  var sessionParams = u.merge(sessionPolicy.options);
+  var sessionParams = u.deepCopy(sessionPolicy.options);
   u.assertArguments(sessionParams, ['nextOutgoingId', 'incomingWindow', 'outgoingWindow']);
 
   this.policy = sessionPolicy;


### PR DESCRIPTION
… instance of the session policy object.

using `_.merge` only references the existing policy object, which means the global policy object gets modified instead of an instance specific to the session later in the code.

changing it to `u.deepCopy` makes sure the session gets its own instance.