### PR TITLE
Make sure transport is destroyed only once if terminate is called multiple times

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -537,15 +537,18 @@ Connection.prototype._saslComplete = function(err) {
 };
 
 Connection.prototype._terminate = function(hasError) {
-  if (this._transport) {
+  var transport = this._transport;
+  this._transport = null;
+
+  if (transport) {
     this._sslOptions = null;
     this.sasl = null;
     this.address = null;
-    this._transport.end();
+    transport.end();
     if (hasError) {
-      this._transport.destroy();
+      transport.destroy();
     }
-    this._transport = null;
+    transport = null;
   }
   if (this._heartbeatInterval) {
     clearInterval(this._heartbeatInterval);


### PR DESCRIPTION
related to https://github.com/noodlefrenzy/node-amqp10-transport-ws/pull/5

Depending on transport implementation, it might be the case that `Connection.terminate()` is called multiple times. In the case of `node-amqp10-transport-ws`, the `end` event was being emitted  synchronously when calling `transport.end()`, which led to a second call to `terminate()`. While executing the second call the transport got destroyed. Then the first call resumes execution and was trying to call `destroy()` on the transport again leading to a `NullReferenceException`.

Using a temporary variable and a null check prevents this from happening and makes sure terminate() can be called multiple times but is effectively trying to destroy the transport only once.
