### PR TITLE
whitespace-only fix indenting in lib/transport

### DIFF
--- a/lib/transport/abstract_transport.js
+++ b/lib/transport/abstract_transport.js
@@ -4,37 +4,37 @@ var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 
 var throwBecauseAbstract = function(methodName) {
-	throw new Error('Cannot use AbstractTransport. Subclass must implement ' + methodName);	
+  throw new Error('Cannot use AbstractTransport. Subclass must implement ' + methodName);
 };
 
 var AbstractTransport = function () {
-	if (this.constructor === AbstractTransport) {
-		throwBecauseAbstract('constructor');
-	}
-	
-	EventEmitter.call(this);
+  if (this.constructor === AbstractTransport) {
+    throwBecauseAbstract('constructor');
+  }
+
+  EventEmitter.call(this);
 };
 
 util.inherits(AbstractTransport, EventEmitter);
 
 AbstractTransport.register = function (client) {
-	throwBecauseAbstract('register');
+  throwBecauseAbstract('register');
 };
 
 AbstractTransport.prototype.connect = function (address) {
-	throwBecauseAbstract('connect');
+  throwBecauseAbstract('connect');
 };
 
 AbstractTransport.prototype.write = function (data) {
-	throwBecauseAbstract('write');
+  throwBecauseAbstract('write');
 };
 
 AbstractTransport.prototype.end = function() {
-	throwBecauseAbstract('end');
+  throwBecauseAbstract('end');
 };
 
 AbstractTransport.prototype.destroy = function() {
-	throwBecauseAbstract('destroy');
+  throwBecauseAbstract('destroy');
 };
 
-module.exports = AbstractTransport; 
+module.exports = AbstractTransport;

--- a/lib/transport/index.js
+++ b/lib/transport/index.js
@@ -10,27 +10,27 @@ function TransportProvider() {
 }
 
 var verifyImplementation = function (transportFactory) {
-  // NOTE: if we only cared about internal modules, 'instanceof' would work, but 
-   // since we're "duck typing" transports to avoid circular dependencies, we have to
-   // verify the transport prototype differently.
-   
+  // NOTE: if we only cared about internal modules, 'instanceof' would work, but
+  // since we're "duck typing" transports to avoid circular dependencies, we have to
+  // verify the transport prototype differently.
+
   var transport = transportFactory();
-   for(var member in AbstractTransport.prototype) {
-     if (AbstractTransport.prototype.hasOwnProperty(member))
+  for(var member in AbstractTransport.prototype) {
+    if (AbstractTransport.prototype.hasOwnProperty(member))
       if (typeof AbstractTransport.prototype[member] !== typeof transport[member]) {
         throw new Error('transport should implement the \'' + member + '\' method.');
       }
-   }
-   
-   if (!(transport instanceof EventEmitter))
-   {
-     throw new Error('transport should inherit from EventEmitter');
-   }
+  }
+
+  if (!(transport instanceof EventEmitter))
+  {
+    throw new Error('transport should inherit from EventEmitter');
+  }
 };
 
 TransportProvider.prototype.registerTransport = function(protocol, transportFactory) {
-   verifyImplementation(transportFactory);
-   this._transportFactories[protocol] = transportFactory;
+  verifyImplementation(transportFactory);
+  this._transportFactories[protocol] = transportFactory;
 };
 
 TransportProvider.prototype.getTransportFor = function(protocol) {
@@ -41,10 +41,10 @@ TransportProvider.prototype.getTransportFor = function(protocol) {
 };
 
 module.exports = (function() {
-   var provider = new TransportProvider();
+  var provider = new TransportProvider();
 
-   // pre-register our "known" transports
-   NetTransport.register(provider);
-   TlsTransport.register(provider);
-   return provider;
+  // pre-register our "known" transports
+  NetTransport.register(provider);
+  TlsTransport.register(provider);
+  return provider;
 })();

--- a/lib/transport/net_transport.js
+++ b/lib/transport/net_transport.js
@@ -6,48 +6,48 @@ var net = require('net');
 var debug = require('debug')('amqp10:transport:net');
 
 var NetTransport = function () {
-	AbstractTransport.call(this);
-	this._socket = null;
+  AbstractTransport.call(this);
+  this._socket = null;
 };
 
 util.inherits(NetTransport, AbstractTransport);
 
 NetTransport.register = function (transportProvider) {
-	transportProvider.registerTransport('amqp', function () { return new NetTransport(); });
+  transportProvider.registerTransport('amqp', function () { return new NetTransport(); });
 };
 
 NetTransport.prototype.connect = function (address) {
-		debug('Connecting to ' + address.host + ':' + address.port + ' via straight-up sockets');
-		this._socket = net.connect({ port: address.port, host: address.host });
-		
-		var self = this;
-		this._socket.on('connect', function() { self.emit('connect'); });
-		this._socket.on('data', function(data) { self.emit('data', data); });
-		this._socket.on('error', function(err) { self.emit('error', err); });
-		this._socket.on('end', function() { self.emit('end'); });
+  debug('Connecting to ' + address.host + ':' + address.port + ' via straight-up sockets');
+  this._socket = net.connect({ port: address.port, host: address.host });
+
+  var self = this;
+  this._socket.on('connect', function() { self.emit('connect'); });
+  this._socket.on('data', function(data) { self.emit('data', data); });
+  this._socket.on('error', function(err) { self.emit('error', err); });
+  this._socket.on('end', function() { self.emit('end'); });
 };
 
 NetTransport.prototype.write = function (data) {
-	if(!this._socket) 
-		throw new Error('Socket not connected');
-	
-	this._socket.write(data);
+  if(!this._socket)
+    throw new Error('Socket not connected');
+
+  this._socket.write(data);
 };
 
 NetTransport.prototype.end = function() {
-	if(!this._socket) 
-		throw new Error('Socket not connected');
-	
-	this._socket.end();
+  if(!this._socket)
+    throw new Error('Socket not connected');
+
+  this._socket.end();
 };
 
 NetTransport.prototype.destroy = function() {
-	if(this._socket) {
-		this._socket.destroy();
-		this._socket = null;
-	}
-	
-	this.removeAllListeners();
+  if(this._socket) {
+    this._socket.destroy();
+    this._socket = null;
+  }
+
+  this.removeAllListeners();
 };
 
-module.exports = NetTransport; 
+module.exports = NetTransport;

--- a/lib/transport/tls_transport.js
+++ b/lib/transport/tls_transport.js
@@ -6,51 +6,51 @@ var tls = require('tls');
 var debug = require('debug')('amqp10:transport:tls');
 
 var TlsTransport = function() {
-	AbstractTransport.call(this);
-	this._socket = null;
+  AbstractTransport.call(this);
+  this._socket = null;
 };
 
 util.inherits(TlsTransport, AbstractTransport);
 
 TlsTransport.register = function (transportProvider) {
-	transportProvider.registerTransport('amqps', function () {return new TlsTransport(); });
+  transportProvider.registerTransport('amqps', function () {return new TlsTransport(); });
 };
 
 TlsTransport.prototype.connect = function (address, sslOpts) {
-	var sslOptions = sslOpts || {};
-	sslOptions.port = address.port;
-	sslOptions.host = address.host;
-	this._socket = tls.connect(sslOptions);
-	debug('Connecting to ' + address.host + ':' + address.port + ' via TLS');
-	
-	var self = this;
-	this._socket.on('secureConnect', function() { self.emit('connect'); });
-	this._socket.on('data', function(data) { self.emit('data', data); });
-	this._socket.on('error', function(err) { self.emit('error', err); });
-	this._socket.on('end', function() { self.emit('end'); });
+  var sslOptions = sslOpts || {};
+  sslOptions.port = address.port;
+  sslOptions.host = address.host;
+  this._socket = tls.connect(sslOptions);
+  debug('Connecting to ' + address.host + ':' + address.port + ' via TLS');
+
+  var self = this;
+  this._socket.on('secureConnect', function() { self.emit('connect'); });
+  this._socket.on('data', function(data) { self.emit('data', data); });
+  this._socket.on('error', function(err) { self.emit('error', err); });
+  this._socket.on('end', function() { self.emit('end'); });
 };
 
 TlsTransport.prototype.write = function (data) {
-	if (!this._socket) 
-		throw new Error('Socket not connected');
-	
-	this._socket.write(data);
+  if (!this._socket)
+    throw new Error('Socket not connected');
+
+  this._socket.write(data);
 };
 
 TlsTransport.prototype.end = function() {
-	if (!this._socket) 
-		throw new Error('Socket not connected');
-	
-	this._socket.end();
+  if (!this._socket)
+    throw new Error('Socket not connected');
+
+  this._socket.end();
 };
 
 TlsTransport.prototype.destroy = function() {
-	if (this._socket) {
-		this._socket.destroy();
-		this._socket = null;
-	}
-	
-	this.removeAllListeners();
+  if (this._socket) {
+    this._socket.destroy();
+    this._socket = null;
+  }
+
+  this.removeAllListeners();
 };
 
-module.exports = TlsTransport; 
+module.exports = TlsTransport;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -189,7 +189,7 @@ utilities.assertArgument = assertArgument;
 
 function range(start, end) {
   var result = [],
-  c = end - start + 1;
+      c = end - start + 1;
   while(c--) result[c] = end--;
   return result;
 }


### PR DESCRIPTION
Seemed to be using tabs rather than the 2 spaces that the rest of the
codebase uses.