### PR TITLE
feat(types): allow DescribedType to be passed as the message.body

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ module.exports = {
   },
 
   TransportProvider: require('./transport'),
+  DescribedType: require('./types/described_type'),
 
   /**
    * translator, which allows you to translate from node-amqp-encoder'd

--- a/lib/types/message.js
+++ b/lib/types/message.js
@@ -175,7 +175,14 @@ module.exports.encodeMessage = function(message, buffer) {
     // @todo:
     //  Array[Buffer] => multiple Data segments
     //  Array[Array] => multiple AMQPSequence
-    if (message.body instanceof Buffer) {
+    if (message.body instanceof DescribedType) {
+      var descriptor = message.body.descriptor;
+      if (!u.includes([0x75, 0x76, 0x77], descriptor)) {
+        throw new errors.MalformedPayloadError(
+            'Invalid described type for message body: ', descriptor);
+      }
+      codec.encode(message.body, buffer);
+    } else if (message.body instanceof Buffer) {
       codec.encode(new DescribedType(0x75, message.body), buffer);  // Data
     } else if (Array.isArray(message.body)) {
       codec.encode(new DescribedType(0x76, message.body), buffer);  // AMQPSequence


### PR DESCRIPTION
Allow a user to create a specific DescribedType in their message.body and honour this at encoding time.

-- 

As a first pass, this exposes a way of satisfying the functionality desired in #255, although it does require use of the internal DescribedType object in the client application. 

An alternative solution would be to allow the user to specify in their policy an encoding map of JavaScript objects and their desired message formats, perhaps exposing constants for the 0x75, 0x76, 0x77 hex type values.