### PR TITLE
refactor(debug): output all received frames

### DIFF
--- a/lib/frames.js
+++ b/lib/frames.js
@@ -115,6 +115,7 @@ frames.readFrame = function(buffer) {
     frame.channel = channel;
   }
 
+  debug('received frame: ', frame, ': ' + payloadBuffer.toString('hex'));
   return frame;
 };
 

--- a/lib/frames.js
+++ b/lib/frames.js
@@ -4,6 +4,7 @@ var Builder = require('buffer-builder'),
     errors = require('./errors'),
     codec = require('./codec'),
     debug = require('debug')('amqp10:framing'),
+    trace = require('debug')('amqp10:trace'),
     constants = require('./constants'),
     types = require('./types'),
     terminus = require('./types/terminus'),
@@ -50,7 +51,8 @@ frames.writeFrame = function(frame, stream) {
 
   var buffer = builder.get();
   buffer.writeUInt32BE(buffer.length, 0);
-  debug('sending frame: ', frame, ': ' + buffer.toString('hex'));
+  debug('sending frame: ', frame);
+  trace('raw: [' + buffer.toString('hex') + ']');
   stream.write(buffer);
 };
 
@@ -73,7 +75,8 @@ frames.readFrame = function(buffer) {
   var payloadSize = size - (doff * 4);
   if (payloadSize <= 0) {
     // @todo: this is probably a heartbeat frame, but what if its not?
-    debug('Heartbeat frame: ' + sizeAndDoff.toString('hex'));
+    debug('received frame: (EMPTY FRAME)');
+    trace('raw: [' + sizeAndDoff.toString('hex') + ']');
     return;
   }
 
@@ -83,7 +86,8 @@ frames.readFrame = function(buffer) {
     buffer.consume(xHeaderSize);
 
     // @todo: Process x-header
-    debug('Read extended header [' + xHeaderBuf.toString('hex') + ']');
+    debug('received extended header');
+    trace('raw: [' + xHeaderBuf.toString('hex') + ']');
   }
 
   // read payload
@@ -115,7 +119,8 @@ frames.readFrame = function(buffer) {
     frame.channel = channel;
   }
 
-  debug('received frame: ', frame, ': ' + payloadBuffer.toString('hex'));
+  debug('received frame: ', frame);
+  trace('raw: [' + payloadBuffer.toString('hex') + ']');
   return frame;
 };
 
@@ -326,6 +331,9 @@ frames.HeartbeatFrame = function() {
 };
 frames.HeartbeatFrame.prototype = Object.create(frames.AMQPFrame.prototype);
 frames.HeartbeatFrame.prototype.toDescribedType = function() { return null; };
+frames.HeartbeatFrame.prototype.inspect = function(depth) {
+  return '(EMPTY FRAME)';
+};
 
 // used to determine if a message should be split to multiple frames
 frames.TRANSFER_FRAME_OVERHEAD = 29;

--- a/lib/session.js
+++ b/lib/session.js
@@ -287,7 +287,6 @@ Session.prototype._nextHandle = function() {
 
 Session.prototype._processFrame = function(frame) {
   if (frame instanceof frames.BeginFrame && (frame.remoteChannel === this.channel)) {
-    debug('processing frame: ', frame);
     this.sessionSM.beginReceived();
     this._beginReceived(frame);
     return;
@@ -298,7 +297,6 @@ Session.prototype._processFrame = function(frame) {
     return;
   }
 
-  debug('processing frame: ', frame);
   if (frame instanceof frames.EndFrame) return this._processEndFrame(frame);
   else if (frame instanceof frames.AttachFrame) return this._processAttachFrame(frame);
   else if (frame instanceof frames.DetachFrame) return this._processDetachFrame(frame);


### PR DESCRIPTION
Previously we were logging a selection of received frames via the
_processFrame handler(s) in session.js, but this ignores (e.g.,) a
received OpenFrame (which is handled in connection.js). It seems more
consistent to be logging received frames within the framing debug where
we currently log all sent frames.