### PR TITLE
fix(heartbeat): local vs remote idleTimeouts

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -149,12 +149,13 @@ function Connection(connectPolicy) {
   this.connectedTo = null;
   this._buffer = new BufferList();
   this._heartbeatInterval = undefined;
+  this._remoteIdleTimeout = undefined;
   this._params = {
     containerId: (typeof options.containerId === 'function') ? options.containerId() : options.containerId,
     hostname: options.hostname,
     maxFrameSize: options.maxFrameSize || constants.defaultMaxFrameSize,
     channelMax: options.channelMax || constants.defaultChannelMax,
-    idleTimeout: options.idleTimeout || constants.defaultIdleTimeout,
+    idleTimeout: (typeof options.idleTimeout === 'number') ? options.idleTimeout :  constants.defaultIdleTimeout,
     outgoingLocales: options.outgoingLocales,
     incomingLocales: options.incomingLocales
   };
@@ -457,8 +458,6 @@ Connection.prototype._processOpenFrame = function(frame) {
 
   this._params.channelMax =
     Math.min(this._params.channelMax, frame.channelMax || constants.defaultChannelMax);
-  this._params.idleTimeout =
-    Math.min(this._params.idleTimeout, frame.idleTimeout || constants.defaultIdleTimeout);
 
   if (frame.outgoingLocales) {
     valid = valid && this._ensureLocaleCompatibility(this._params.incomingLocales, frame.outgoingLocales);
@@ -472,19 +471,25 @@ Connection.prototype._processOpenFrame = function(frame) {
   }
 
   // We're connected.
-  debug('Connected with params { maxFrameSize=' + this._params.maxFrameSize + ', channelMax=' + this._params.channelMax + ', idleTimeout=' + this._params.idleTimeout + ' }');
+  debug('Connected with params { maxFrameSize=' + this._params.maxFrameSize +
+        ', channelMax=' + this._params.channelMax + ', idleTimeout=' +
+        this._params.idleTimeout + ', remoteIdleTimeout=' + frame.idleTimeout +
+        '}');
   this.connected = true;
   this._lastOutgoing = Date.now();
-  var maxTimeBeforeHeartbeat = Math.floor(this._params.idleTimeout / 2);
-  var timeBetweenHeartbeatChecks = Math.floor(this._params.idleTimeout / 8);
+  this._remoteIdleTimeout = frame.idleTimeout;
+  if (this._remoteIdleTimeout && Number(this._remoteIdleTimeout) > 0) {
+    var maxTimeBeforeHeartbeat = Math.floor(this._remoteIdleTimeout / 2);
+    var timeBetweenHeartbeatChecks = Math.floor(this._remoteIdleTimeout / 8);
 
-  debug('Setting heartbeat check timeout to ' + timeBetweenHeartbeatChecks);
-  var self = this;
-  this._heartbeatInterval = setInterval(function() {
-    if (self.connected && self._transport && (Date.now() - self._lastOutgoing) > maxTimeBeforeHeartbeat) {
-      self.sendFrame(new frames.HeartbeatFrame());
-    }
-  }, timeBetweenHeartbeatChecks);
+    debug('Setting heartbeat check timeout to ' + timeBetweenHeartbeatChecks);
+    var self = this;
+    this._heartbeatInterval = setInterval(function() {
+      if (self.connected && self._transport && (Date.now() - self._lastOutgoing) > maxTimeBeforeHeartbeat) {
+        self.sendFrame(new frames.HeartbeatFrame());
+      }
+    }, timeBetweenHeartbeatChecks);
+  }
 
   this.emit(Connection.Connected, this);
   if (this._buffer.length) this._receiveAny(); // Might have more frames pending.


### PR DESCRIPTION
There were a couple of bugs here:
- you couldn't specify a 0 for (local) idleTimeout, so we always flowed
  something in our OpenFrame
- the client was incorrectly selecting a minimum value between the local
  and remote idleTimeouts and then using that as the frequency with
  which empty frames should be sent to the server. It should only obey
  the remoteIdleTimeout for emitting heartbeats

NB: currently, although we flow an idleTimeout in our OpenFrame, we
don't actually monitor whether or not the remote-end actually sends us
data within this interval, nor do we disconnect them if they don't.