### PR TITLE
fix(sasl): pass errors to callback, don't throw

### DIFF
--- a/lib/sasl.js
+++ b/lib/sasl.js
@@ -66,8 +66,8 @@ Sasl.prototype._processFrame = function(frame) {
     var mechanisms = Array.isArray(frame.saslServerMechanisms) ?
       frame.saslServerMechanisms.map(function(m) { return m.value; }) : frame.saslServerMechanisms;
     if (!u.includes(mechanisms, mechanism)) {
-      throw new errors.AuthenticationError(
-        'SASL ' + mechanism + ' not supported by remote.');
+      this.callback(new errors.AuthenticationError(
+        'SASL ' + mechanism + ' not supported by remote.'));
     }
     if (mechanism === Sasl.Mechanism.PLAIN) {
       debug('Sending ' + this.credentials.user + ':' + this.credentials.pass);
@@ -82,8 +82,8 @@ Sasl.prototype._processFrame = function(frame) {
       }
       buf.appendUInt8(0); // <null>
     } else {
-      throw new errors.NotImplementedError(
-          'Only SASL PLAIN and ANONYMOUS are supported.');
+      this.callback(new errors.NotImplementedError(
+          'Only SASL PLAIN and ANONYMOUS are supported.'));
     }
     var initFrame = new frames.SaslInitFrame({
       mechanism: mechanism,


### PR DESCRIPTION
This sends them through the normal connectionError chain rather than just throwing them in place which ends up on the uncaughtException handler.