### PR TITLE
Only decode extra byte if not forcedCode

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -72,12 +72,12 @@ Codec.prototype._readFullValue = function(buf, offset, doNotConsume, forcedCode)
   var codePrefix = code & 0xF0;
   var codeAndLength, numBytes;
   switch (codePrefix) {
-    case 0x40: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 1);
-    case 0x50: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 2);
-    case 0x60: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 3);
-    case 0x70: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 5);
-    case 0x80: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 9);
-    case 0x90: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 17);
+    case 0x40: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 0 + codeBytes);
+    case 0x50: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 1 + codeBytes);
+    case 0x60: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 2 + codeBytes);
+    case 0x70: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 4 + codeBytes);
+    case 0x80: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 8 + codeBytes);
+    case 0x90: return this._readOrPeekFixed(buf, offset, remaining, doNotConsume, 16 + codeBytes);
     case 0xA0:
     case 0xC0:
     case 0xE0:

--- a/test/unit/test_codec.js
+++ b/test/unit/test_codec.js
@@ -80,6 +80,15 @@ describe('Codec', function() {
       expect(function() { codec.decode(buffer); }).to.throw(Error);
     });
 
+    it('should decode arrays', function() {
+        var buffer = newBuffer([0xe0, 0x0a, 0x01, 0x83, 0x00, 0x00, 0x01, 0x58, 0x06, 0xf2, 0xfb, 0xc7]);
+        var actual = codec.decode(buffer);
+        expect(actual[0]).to.be.instanceof(Array);
+        expect(actual[0][0]).to.be.instanceof(Date);
+        expect(actual[0][0].getTime()).to.eql(0x15806f2fbc7);
+        expect(actual[1]).to.eql(12);
+    });
+
     it('should decode described types', function() {
       var buffer = newBuffer([0x00, 0xA1, 0x03, Builder.prototype.appendString, 'URL', 0xA1, 0x1E, Builder.prototype.appendString, 'http://example.org/hello-world']);
       var actual = codec.decode(buffer);


### PR DESCRIPTION
Addresses the bug in #274 by only reading an extra byte for fixed-width values if the code is not provided by `forcedCode`