### PR TITLE
Allow link address to be overridden in createSender()/createReceiver()

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -195,10 +195,9 @@ AMQPClient.prototype.createSender = function(address, policyOverrides) {
       linkPolicy = u.deepMerge({
         attach: {
           name: linkName,
-          source: { address: 'localhost' },
           target: { address: address.name }
         }
-      }, policyOverrides, this.policy.senderLink);
+      }, policyOverrides, { attach: { source: { address: 'localhost' } } }, this.policy.senderLink);
 
   if (!!address.subject && this.policy.defaultSubjects) {
     if (address.subject === 'undefined' || address.subject === 'null') {
@@ -262,10 +261,9 @@ AMQPClient.prototype.createReceiver = function(address, policyOverrides) {
       linkPolicy = u.deepMerge({
         attach: {
           name: linkName,
-          source: { address: address.name },
-          target: { address: 'localhost' }
+          source: { address: address.name }
         }
-      }, policyOverrides, this.policy.receiverLink);
+      }, policyOverrides, { attach: { target: { address: 'localhost' } } }, this.policy.receiverLink);
 
   // if a subject has been provided then automatically set up a filter to
   // match on that subject.


### PR DESCRIPTION
Addresses #277 by reordering the policy merge parameters on `createSender()` and `createReceiver()`. With this change, it is possible to override the source address to be overridden on `createSender()` and the target address on `createReceiver()`. This is relevant for use cases such as [AMQP request/response](https://www.oasis-open.org/committees/download.php/52425/amqp-man-v1%200-wd08.pdf?p=17).

The opposite address can already be overridden by other means, so it was not moved.
