### PR TITLE
refactor(link-policy): reorder link policy merge during create

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -192,13 +192,13 @@ AMQPClient.prototype.createSender = function(address, policyOverrides) {
   policyOverrides = policyOverrides || {};
 
   var linkName = u.linkName(address.name, policyOverrides),
-      linkPolicy = u.deepMerge({
+      linkPolicy = u.deepMerge(policyOverrides, {
         attach: {
           name: linkName,
           source: { address: 'localhost' },
           target: { address: address.name }
         }
-      }, policyOverrides, this.policy.senderLink);
+      }, this.policy.senderLink);
 
   if (!!address.subject && this.policy.defaultSubjects) {
     if (address.subject === 'undefined' || address.subject === 'null') {
@@ -259,13 +259,13 @@ AMQPClient.prototype.createReceiver = function(address, policyOverrides) {
   policyOverrides = policyOverrides || {};
 
   var linkName = u.linkName(address.name, policyOverrides),
-      linkPolicy = u.deepMerge({
+      linkPolicy = u.deepMerge(policyOverrides, {
         attach: {
           name: linkName,
           source: { address: address.name },
           target: { address: 'localhost' }
         }
-      }, policyOverrides, this.policy.receiverLink);
+      }, this.policy.receiverLink);
 
   // if a subject has been provided then automatically set up a filter to
   // match on that subject.

--- a/test/unit/mocks/index.js
+++ b/test/unit/mocks/index.js
@@ -1,4 +1,7 @@
 'use strict';
+var constants = require('../../../lib/constants'),
+    AMQPError = require('../../../lib/types/amqp_error'),
+    ErrorCondition = require('../../../lib/types/error_condition');
 
 module.exports = {
   Client: require('./client'),
@@ -6,5 +9,29 @@ module.exports = {
   Connection: require('./connection'),
   Session: require('./session'),
   SenderLink: require('./sender_link'),
-  ReceiverLink: require('./receiver_link')
+  ReceiverLink: require('./receiver_link'),
+
+  // useful default options
+  Defaults: {
+    begin: {
+      remoteChannel: 1, nextOutgoingId: 0,
+      incomingWindow: 100000, outgoingWindow: 2147483647,
+      handleMax: 4294967295
+    },
+    attach: {
+      handle: 1,
+      role: constants.linkRole.sender,
+      source: {}, target: {},
+      initialDeliveryCount: 0
+    },
+    flow: {
+      handle: 1, deliveryCount: 1,
+      nextIncomingId: 1, incomingWindow: 2147483647,
+      nextOutgoingId: 0, outgoingWindow: 2147483647,
+      linkCredit: 500
+    },
+    close: {
+      error: new AMQPError({ condition: ErrorCondition.ConnectionForced, description: 'test' })
+    }
+  }
 };

--- a/test/unit/sender_link.test.js
+++ b/test/unit/sender_link.test.js
@@ -11,6 +11,8 @@ var chai = require('chai'),
     Policy = require('../../lib/policies/policy'),
     DeliveryState = require('../../lib/types/delivery_state'),
 
+    u = require('../../lib/utilities'),
+    md = require('./mocks').Defaults,
     test = require('./test-fixture');
 
 chai.use(require('chai-as-promised'));
@@ -21,58 +23,77 @@ var TestPolicy = new Policy({
 });
 
 describe('SenderLink', function() {
-  describe('#send', function() {
-    beforeEach(function() {
-      if (!!test.server) test.server = undefined;
-      if (!!test.client) test.client = undefined;
-      test.client = new AMQPClient(TestPolicy);
-      test.server = new MockServer();
-      return test.server.setup();
-    });
+  beforeEach(function() {
+    if (!!test.server) test.server = undefined;
+    if (!!test.client) test.client = undefined;
+    test.client = new AMQPClient(TestPolicy);
+    test.server = new MockServer();
+    return test.server.setup();
+  });
 
-    afterEach(function() {
-      if (!test.server) return;
-      return test.server.teardown()
-        .then(function() { test.server = undefined; });
-    });
+  afterEach(function() {
+    if (!test.server) return;
+    return test.server.teardown()
+      .then(function() { test.server = undefined; });
+  });
 
-    it('should reject send promises with default reason if rejected disposition provides none', function() {
-      test.server.setResponseSequence([
-        constants.amqpVersion,
-        new frames.OpenFrame({ containerId: 'test' }),
-        new frames.BeginFrame({
-          remoteChannel: 1, nextOutgoingId: 0, incomingWindow: 100000,
-          outgoingWindow: 2147483647, handleMax: 4294967295
-        }),
-        [
-          function (prev) {
-            var rxAttach = frames.readFrame(prev[prev.length-1]);
-            return new frames.AttachFrame({
-              name: rxAttach.name, handle: 1, role: constants.linkRole.receiver,
-              source: {}, target: {}, initialDeliveryCount: 0
-            });
-          },
-          new frames.FlowFrame({
-            handle: 1, deliveryCount: 1,
-            nextIncomingId: 1, incomingWindow: 2147483647,
-            nextOutgoingId: 0, outgoingWindow: 2147483647,
-            linkCredit: 500
-          })
-        ],
-        new frames.DispositionFrame({
-          role: constants.linkRole.receiver, first: 1, last: 1, settled: true, batchable: false,
-          state: new DeliveryState.Rejected()
-        })
-      ]);
+  it('should reject send promises with default reason if rejected disposition provides none', function() {
+    test.server.setResponseSequence([
+      constants.amqpVersion,
+      new frames.OpenFrame({ containerId: 'test' }),
+      new frames.BeginFrame(md.begin),
+      [
+        function (prev) {
+          var rxAttach = frames.readFrame(prev[prev.length-1]);
+          return new frames.AttachFrame(u.deepMerge({
+            name: rxAttach.name, role: constants.linkRole.receiver,
+          }, md.attach));
+        },
+        new frames.FlowFrame(md.flow)
+      ],
+      new frames.DispositionFrame({
+        role: constants.linkRole.receiver, first: 1, last: 1, settled: true, batchable: false,
+        state: new DeliveryState.Rejected()
+      })
+    ]);
 
-      return test.client.connect(test.server.address())
-        .then(function() { return test.client.createSender('test.link'); })
-        .then(function(sender) {
-          var sendPromise = sender.send('llamas');
-          return expect(sendPromise)
-            .to.eventually.be.rejectedWith('Message was rejected');
+    return test.client.connect(test.server.address())
+      .then(function() { return test.client.createSender('test.link'); })
+      .then(function(sender) {
+        var sendPromise = sender.send('llamas');
+        return expect(sendPromise)
+          .to.eventually.be.rejectedWith('Message was rejected');
+      });
+  });
+
+  it('should allow the source address to be overridden on send', function() {
+    test.server.setResponseSequence([
+      constants.amqpVersion,
+      new frames.OpenFrame({ containerId: 'test' }),
+      new frames.BeginFrame(md.begin),
+      [
+        function (prev) {
+          var rxAttach = frames.readFrame(prev[prev.length-1]);
+          return new frames.AttachFrame(u.deepMerge({
+            name: rxAttach.name, role: constants.linkRole.receiver
+          }, md.attach));
+        },
+        new frames.FlowFrame(md.flow)
+      ],
+      new frames.CloseFrame(md.close)
+    ]);
+
+    var sourceAddress = 'customSourceAddress';
+    return test.client.connect(test.server.address())
+      .then(function() {
+        return test.client.createSender('test.link', {
+          attach: { source: { address: sourceAddress } }
         });
-    });
+      })
+      .then(function(sender) {
+        expect(sender.policy.attach.source.address).to.eql(sourceAddress);
+        return test.client.disconnect();
+      });
   });
 
 });


### PR DESCRIPTION
Through an initial misunderstanding of the order of operations when
using `u.deepMerge` link policies at link creation were erroneously
overwriting user provided policyOverrides. This patch corrects this
behavior.
