### PR TITLE
Prevent exception if transport is already null when Connection.prototype._terminate() is called twice

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -530,15 +530,16 @@ Connection.prototype._saslComplete = function(err) {
 };
 
 Connection.prototype._terminate = function(hasError) {
-  if (this._transport) {
-    this._sslOptions = null;
-    this.sasl = null;
-    this.address = null;
-    this._transport.end();
+  var transport = this._transport;
+  this._transport = null;
+  this._sslOptions = null;
+  this.sasl = null;
+  this.address = null;
+  if (transport) {
+    transport.end();
     if (hasError) {
-      this._transport.destroy();
+      transport.destroy();
     }
-    this._transport = null;
   }
 
   if (this._heartbeatInterval) {


### PR DESCRIPTION
Using node 0.10, when `Connection.prototype._terminate()` is called, `this._transport.end()` calls `socket.end()` which generates an event that leads to `_terminate()` being called again synchronously (meaning the first call to `_terminate()` is still waiting for `this._transport.end()` to return while the second call nullifies the `_transport` object. 

Once the second call is finished, the first call continues and throws an exception when trying to call `this._transport.terminate()`.

This PR should prevent that from happening :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/290)
<!-- Reviewable:end -->
