### PR TITLE
Add UUID support for encoder

### DIFF
--- a/lib/adapters/translate_encoder.js
+++ b/lib/adapters/translate_encoder.js
@@ -30,6 +30,8 @@ var encoder = processor({
         return null;
       case 'boolean':
         return val;
+      case 'uuid':
+        return new ForcedType('uuid', val);
       default:
         throw new Error('Unknown fixed: ' + type);
     }


### PR DESCRIPTION
related to https://github.com/noodlefrenzy/node-amqp-encoder/pull/2

The goal is to add the ability for the user to force the UUID type on properties, and especially on the messageId and correlationId properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/294)
<!-- Reviewable:end -->
