### PR TITLE
Fix documentation to reference correct annotation field name

### DIFF
--- a/lib/sender_link.js
+++ b/lib/sender_link.js
@@ -58,10 +58,10 @@ SenderLink.prototype.canSend = function() {
  *                                    options are: 'sent', 'settled' and 'none'. For the best performance
  *                                    choose 'none', which is essentially "send and forget" and notably will
  *                                    not return a promise.
- * @param {object} [options.annotations] Annotations for the message, if any.  See AMQP spec for details, and server for specific
- *                                       annotations that might be relevant (e.g. x-opt-partition-key on EventHub).  If node-amqp-encoder'd
- *                                       map is given, it will be translated to appropriate internal types.  Simple maps will be converted
- *                                       to AMQP Fields type as defined in the spec.
+ * @param {object} [options.messageAnnotations] Annotations for the message, if any.  See AMQP spec for details, and server for specific
+ *                                              annotations that might be relevant (e.g. x-opt-partition-key on EventHub).  If node-amqp-encoder'd
+ *                                              map is given, it will be translated to appropriate internal types.  Simple maps will be converted
+ *                                              to AMQP Fields type as defined in the spec.
  *
  * @return {Promise|null}
  */


### PR DESCRIPTION
Some libraries that make use of this library (https://github.com/Azure/azure-event-hubs-node) were making use of the option field as "annotations" rather than "messageAnnotations." This caused failures when setting the partition key in Azure Event Hubs. Simple fix below to update some of the documentation. It looks correct in other spots. Not sure if the field changed at a certain point?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/308)
<!-- Reviewable:end -->
