### PR TITLE
fix(recv-link): distinguish auto/manual settlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ Where the first number is the initial credit, and the second is the _threshold_ 
 
 1. Sets the Link's creditQuantum to the first number (1), which you can do for yourself via the Policy mix-in `{ receiverLink: { creditQuantum: 1 } }`
 
-2. Sets the Link to not auto-settle messages at the sender, which you can do for yourself via `{ receiverLink: { attach: { receiverSettleMode: 1 } } }`
- Where did that magic "1" come from? Well, that's the value from the spec, but you could use the constant we've defined at `require('amqp10').Constants.receiverSettleMode.settleOnDisposition`
+2. Sets the Link to not auto-settle messages at the sender
 
 3. Sets the Link's credit renewal policy to a custom method that renews only when the link credit is below the threshold and we've settled some messages. You can do this yourself by using your own custom method:
 ```

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -53,8 +53,12 @@ var Constants = {
     mixed: 2
   },
   receiverSettleMode: {
-    autoSettle: 0,
-    settleOnDisposition: 1
+    first: 0,
+    second: 1
+  },
+  settlement: {
+    auto: 0,
+    manual: 1,
   },
   terminusDurability: {
     none: 0,

--- a/lib/policies/policy.js
+++ b/lib/policies/policy.js
@@ -168,12 +168,13 @@ function Policy(overrides) {
       attach: {
         name: linkName('receiver'),
         role: constants.linkRole.receiver,
-        rcvSettleMode: constants.receiverSettleMode.autoSettle,
+        rcvSettleMode: constants.receiverSettleMode.first,
         maxMessageSize: 10000, // Arbitrary choice
         initialDeliveryCount: 1
       },
       credit: putils.CreditPolicies.RefreshAtHalf,
       creditQuantum: 100,
+      settlement: constants.settlement.auto,
       decoder: null,
       reattach: null
     },

--- a/lib/policies/policy_utilities.js
+++ b/lib/policies/policy_utilities.js
@@ -40,7 +40,7 @@ var CreditPolicies = {
   },
   RefreshSettled: function (threshold) {
     return function (link, options) {
-      if (link.policy.rcvSettleMode === constants.receiverSettleMode.autoSettle) {
+      if (link.policy && link.policy.settlement === constants.settlement.auto) {
         throw new errors.InvalidStateError('Cannot specify RefreshSettled as link refresh policy when auto-settling messages.');
       }
       var creditQuantum = (!!options && options.initial) ? link.policy.creditQuantum : link.settledMessagesSinceLastCredit;
@@ -107,9 +107,7 @@ module.exports.RenewOnSettle = function(initialCredit, threshold, basePolicy) {
     receiverLink: {
       credit: CreditPolicies.RefreshSettled(threshold),
       creditQuantum: initialCredit,
-      attach: {
-        rcvSettleMode: constants.receiverSettleMode.settleOnDisposition
-      }
+      settlement: constants.settlement.manual
     }
   }, basePolicy);
 };

--- a/lib/receiver_link.js
+++ b/lib/receiver_link.js
@@ -192,7 +192,7 @@ ReceiverLink.prototype._messageReceived = function(transferFrame) {
   // @todo: Bump link credit based on strategy
 
   // respect settle mode in policy
-  if (this.policy.settlement === constants.settlement.manual) {
+  if (this.policy.settlement === constants.settlement.auto) {
     this.accept(message);
   }
 

--- a/lib/receiver_link.js
+++ b/lib/receiver_link.js
@@ -20,7 +20,7 @@ var util = require('util'),
 function ReceiverLink(session, handle, linkPolicy) {
   ReceiverLink.super_.call(this, session, handle, linkPolicy);
   // If we're not auto-settling, we should track settles to allow refresh policies to decide when to re-up.
-  this._trackSettles = linkPolicy && linkPolicy.attach && linkPolicy.attach.rcvSettleMode !== constants.receiverSettleMode.autoSettle;
+  this._trackSettles = linkPolicy && linkPolicy.settlement === constants.settlement.manual;
   this._currentTransferFrame = null;
   if (this._trackSettles) this.settledMessagesSinceLastCredit = 0;
 }
@@ -192,7 +192,7 @@ ReceiverLink.prototype._messageReceived = function(transferFrame) {
   // @todo: Bump link credit based on strategy
 
   // respect settle mode in policy
-  if (this.policy.attach.rcvSettleMode === constants.receiverSettleMode.autoSettle) {
+  if (this.policy.settlement === constants.settlement.manual) {
     this.accept(message);
   }
 

--- a/test/integration/qpid/disposition.test.js
+++ b/test/integration/qpid/disposition.test.js
@@ -88,9 +88,6 @@ describe('Disposition', function() {
         return Promise.all([
           test.broker.initialize(),
           test.client.createReceiver(queueName, {
-            attach: {
-              rcvSettleMode: c.receiverSettleMode.settleOnDisposition
-            },
             creditQuantum: 1
           }),
           test.client.createSender(queueName)

--- a/test/unit/frames.test.js
+++ b/test/unit/frames.test.js
@@ -374,7 +374,7 @@ describe('AttachFrame', function() {
     expect(attach.handle).to.eql(0);
     expect(attach.role).to.eql(true);
     expect(attach.sndSettleMode).to.eql(constants.senderSettleMode.mixed);
-    expect(attach.rcvSettleMode).to.eql(constants.receiverSettleMode.autoSettle);
+    expect(attach.rcvSettleMode).to.eql(constants.receiverSettleMode.first);
   });
 
   it('should decode performative correctly (2)', function() {
@@ -397,7 +397,7 @@ describe('AttachFrame', function() {
     expect(attach.handle).to.eql(0);
     expect(attach.role).to.eql(true);
     expect(attach.sndSettleMode).to.eql(constants.senderSettleMode.mixed);
-    expect(attach.rcvSettleMode).to.eql(constants.receiverSettleMode.autoSettle);
+    expect(attach.rcvSettleMode).to.eql(constants.receiverSettleMode.first);
   });
 
   it('should decode performative correctly (3)', function() {
@@ -454,7 +454,7 @@ describe('AttachFrame', function() {
     expect(attach.handle).to.eql(1);
     expect(attach.role).to.eql(false);
     expect(attach.sndSettleMode).to.eql(constants.senderSettleMode.mixed);
-    expect(attach.rcvSettleMode).to.eql(constants.receiverSettleMode.autoSettle);
+    expect(attach.rcvSettleMode).to.eql(constants.receiverSettleMode.first);
     expect(attach.properties).to.eql({
       'com.microsoft:client-version': 'azure-iot-device/1.0.0-preview.9'
     });
@@ -628,7 +628,7 @@ describe('TransferFrame', function() {
       deliveryTag: tu.buildBuffer([1]),
       messageFormat: 20000,
       settled: true,
-      rcvSettleMode: constants.receiverSettleMode.autoSettle
+      rcvSettleMode: constants.receiverSettleMode.first
     });
     transfer.channel = 1;
     transfer.payload = new Buffer([0x00, 0x53, 0x77, 0x52, 10]);
@@ -733,7 +733,7 @@ describe('TransferFrame', function() {
     expect(transfer).to.be.an.instanceOf(frames.TransferFrame);
     expect(transfer.channel).to.eql(channel);
     expect(transfer.handle).to.eql(handle);
-    expect(transfer.rcvSettleMode).to.eql(constants.receiverSettleMode.autoSettle);
+    expect(transfer.rcvSettleMode).to.eql(constants.receiverSettleMode.first);
     expect(transfer.payload).to.have.length(5);
 
     // var message = transfer.decodePayload();

--- a/test/unit/test_utilities.js
+++ b/test/unit/test_utilities.js
@@ -78,7 +78,7 @@ describe('Utilities', function() {
           address: 'localhost'
         }),
         sndSettleMode: constants.senderSettleMode.settled,
-        rcvSettleMode: constants.receiverSettleMode.autoSettle,
+        rcvSettleMode: constants.receiverSettleMode.first,
         maxMessageSize: 10000,
         initialDeliveryCount: 1
       }};


### PR DESCRIPTION
This should probably be a major version bump as the API is changed

- default to rcv-settle-mode "first" everywhere, we don't currently handle
  "second" correctly anyway
- add link policy attribute "settlement" to distinguish between auto,
  where the client will immediately accept messages on receipt, and manual
  where the user is expected to call accept when they have finished
  handling a delivery.

Fixes #316

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/317)
<!-- Reviewable:end -->
