### PR TITLE
fix(address-parsing): don't truncate ':' passwords

### DIFF
--- a/lib/policies/policy.js
+++ b/lib/policies/policy.js
@@ -237,11 +237,13 @@ Policy.prototype.parseAddress = function(address) {
 
   result.rootUri = result.protocol + '://';
   if (!!parsedAddress.auth) {
-    result.rootUri += parsedAddress.auth + '@';
-
-    var userPass = parsedAddress.auth.split(':', 2);
-    result.user = userPass[0];
-    result.pass = userPass[1] || null;
+    // capture the part of the encoded URI between '//' and '@'
+    var matchAuth = /amqps?:\/\/([^@]+).+/g;
+    var auth = matchAuth.exec(address)[1];
+    result.rootUri += auth + '@';
+    var authSplit = auth.split(':', 2);
+    result.user = decodeURIComponent(authSplit[0]);
+    result.pass = (authSplit[1]) ? decodeURIComponent(authSplit[1]) : null;
   }
 
   result.rootUri += result.host + ':' + result.port;

--- a/test/unit/address.test.js
+++ b/test/unit/address.test.js
@@ -92,6 +92,16 @@ describe('Address Parsing', function() {
           rootUri: 'amqps://username:password@192.168.1.1:1234',
           href: 'amqps://username:password@192.168.1.1:1234/myroute'
         }
+      },
+      {
+        description: 'should match credentials if passwd contains colons',
+        address: 'amqp://username:ii%7DS%3Aae3@my.amqp.server',
+        expected: {
+          protocol: 'amqp', host: 'my.amqp.server', port: 5672, path: '/',
+          user: 'username', pass: 'ii}S:ae3',
+          rootUri: 'amqp://username:ii%7DS%3Aae3@my.amqp.server:5672',
+          href: 'amqp://username:ii%7DS:ae3@my.amqp.server'
+        }
       }
     ].forEach(function(testCase) {
       it('should match ' + testCase.description, function() {


### PR DESCRIPTION
Fix a bug which truncated passwords containing a ':' character because
the parseAddress function relied upon node's url.parse().auth which
returns the user:pass pair already URI-decoded.

Fixes #318

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/319)
<!-- Reviewable:end -->
