### PR TITLE
update tests to support different runtime versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "devDependencies": {
     "benchmark": "^2.1.2",
     "chai": "^3.5.0",
-    "chai-string": "^1.3.0",
     "chai-as-promised": "^6.0.0",
+    "chai-string": "^1.3.0",
     "conventional-changelog-cli": "^1.2.0",
     "gh-pages": "^0.12.0",
     "istanbul": "^0.4.5",
@@ -27,6 +27,7 @@
     "jshint": "^2.9.4",
     "mocha": "^3.2.0",
     "qmf2": "^0.1.5",
+    "semver": "^5.4.1",
     "stream-buffers": "^3.0.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqp10",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Native AMQP-1.0 client for node.js",
   "main": "./lib",
   "engines": {

--- a/test/testing_utils.js
+++ b/test/testing_utils.js
@@ -4,6 +4,7 @@ var Builder = require('buffer-builder'),
     expect = require('chai').expect,
     _ = require('lodash'),
     sb = require('stream-buffers'),
+    semver = require('semver'),
     frames = require('../lib/frames');
 
 function populateConfig(configKeyMap, cb) {
@@ -120,7 +121,6 @@ module.exports.convertFrameToBuffer = function(frame) {
   return buffer.getContents();
 };
 
-
 module.exports.bufferEqual = function(a, b) {
   if (!Buffer.isBuffer(a)) return undefined;
   if (!Buffer.isBuffer(b)) return undefined;
@@ -133,3 +133,20 @@ module.exports.bufferEqual = function(a, b) {
 
   return true;
 };
+
+/**
+ * Ensures a test case is expected to be run
+ * given our current runtime versions
+ * 
+ * @param {Object} testCase test object to ensure
+ * @returns {Boolean} success or failure flag
+ */
+module.exports.ensureCompatibleTest = function(testCase) {
+  for (var prop in testCase.compatibleWith) {
+    if (!semver.satisfies(process.versions[prop], testCase.compatibleWith[prop])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/test/testing_utils.js
+++ b/test/testing_utils.js
@@ -149,4 +149,4 @@ module.exports.ensureCompatibleTest = function(testCase) {
   }
 
   return true;
-}
+};

--- a/test/unit/address.test.js
+++ b/test/unit/address.test.js
@@ -4,6 +4,7 @@ var Policies = require('../../lib').Policy,
     QpidJavaPolicy = Policies.QpidJava,
     ActiveMQPolicy = Policies.ActiveMQ,
     expect = require('chai').expect,
+    ensureCompatibleTest = require('../testing_utils').ensureCompatibleTest,
     u = require('../../lib/utilities');
 
 describe('Address Parsing', function() {
@@ -94,21 +95,39 @@ describe('Address Parsing', function() {
         }
       },
       {
-        description: 'should match credentials if passwd contains colons',
+        description: 'should match credentials if passwd contains colons (node >= 5.7.0)',
         address: 'amqp://username:ii%7DS%3Aae3@my.amqp.server',
         expected: {
           protocol: 'amqp', host: 'my.amqp.server', port: 5672, path: '/',
           user: 'username', pass: 'ii}S:ae3',
           rootUri: 'amqp://username:ii%7DS%3Aae3@my.amqp.server:5672',
           href: 'amqp://username:ii%7DS:ae3@my.amqp.server'
+        },
+        compatibleWith: {
+          node: '>=5.7.0'
+        }
+      },
+      {
+        description: 'should match credentials if passwd contains colons (node <5.7.0)',
+        address: 'amqp://username:ii%7DS%3Aae3@my.amqp.server',
+        expected: {
+          protocol: 'amqp', host: 'my.amqp.server', port: 5672, path: '/',
+          user: 'username', pass: 'ii}S:ae3',
+          rootUri: 'amqp://username:ii%7DS%3Aae3@my.amqp.server:5672',
+          href: 'amqp://username:ii%7DS%3Aae3@my.amqp.server'
+        },
+        compatibleWith: {
+          node: '<5.7.0'
         }
       }
     ].forEach(function(testCase) {
-      it('should match ' + testCase.description, function() {
-        var policy = DefaultPolicy;
-        expect(policy.parseAddress(testCase.address))
-          .to.eql(testCase.expected);
-      });
+      if (ensureCompatibleTest(testCase)) {
+        it('should match ' + testCase.description, function() {
+          var policy = DefaultPolicy;
+          expect(policy.parseAddress(testCase.address))
+            .to.eql(testCase.expected);
+        });
+      }
     });
   });
 


### PR DESCRIPTION
- [x] fix breaking tests
- [ ] update semver patch before shipping
- [x] remove `.travis.yml` changes

A [couple of tests](https://travis-ci.org/noodlefrenzy/node-amqp10/builds/234319960) fail on the master branch, as a result of downlevel changes in node core. Specifically, `node>=5.7.0` adds [encodeAuth()](https://github.com/nodejs/node/commit/db9128135f382e22202d900263e872d8b48f0050#diff-bbc5176adff1bbc01acd61bfc85d049fR924) (see [changelog](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V5.md#2016-02-23-version-570-stable-rvagg) for which release it landed in - `5.7.0`) which inteligently __doesn't__ encode `:` as a uri component when creating a [Url](https://nodejs.org/api/url.html#url_class_url). Rather than make any changes to our library to normalize this behavior across versions (which feels like a bad fix, since this behavior is consistent with core) we added support conditionally executing tests based on a version check against the current runtime.

We apply this new version checking behavior to the failing test, and provide an additional new test - the result is a version for `node < 5.7.0` and a __different__ version for `node >= 5.7.0`, to test both expected behaviors on the respective runtimes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/329)
<!-- Reviewable:end -->
