### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,12 @@ branches:
   except:
     - gh-pages
 
-addons:
-  apt:
-   sources:
-   - sourceline: 'ppa:qpid/testing'
-   packages:
-   - qpidd
-   - qpid-tools
-
 before_install:
   - npm install -g codeclimate-test-reporter
+  - sudo sh -c 'printf "start on (started networking and filesystem)\nstop on runlevel [!2345]\n\nexpect fork\npre-start script\n\tmkdir -p /var/lib/qpidd/\nend script\n\nscript\n\texec qpidd -d --config /etc/qpid/qpidd.conf\nend script\n" > /etc/init/qpidd.conf'
+  - sudo add-apt-repository -y ppa:qpid/testing
+  - sudo apt-get update -qq
+  - sudo apt-get install -y qpidd qpid-tools
 
 before_script:
   - sudo sh -c 'echo "auth=no" >> /etc/qpid/qpidd.conf'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 before_script:
   - sudo sh -c 'echo "auth=no" >> /etc/qpid/qpidd.conf'
-  - sudo /etc/init.d/qpidd restart
+  - sudo service qpidd restart
 
   # remove these when we can specify link properties
   - sudo qpid-config add queue test.disposition.queue


### PR DESCRIPTION
Since v1.36.0 for qpidd, the package fails to build, due to issues with the `init.d` (see https://issues.apache.org/jira/browse/QPID-7863)
As a result travis has been failing
As a work around, I have added a basic `upstart` script, and moved the installation of `qpidd` and `qpid-tools` to the `before_install` section of the travis file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/330)
<!-- Reviewable:end -->
