### PR TITLE
feat(session): add support for multiple sessions per client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ script:
   - make coverage
 
 after_script:
-  - codeclimate-test-reporter < coverage/lcov.info
+- codeclimate-test-reporter < coverage/lcov.info

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -68,6 +68,8 @@ function AMQPClient(policy, policyOverrides) {
 
   this._connection = null;
   this._session = null;
+  this._sessionPromise = null;
+  this._userSessions = [];
 
   this._reconnect = null;
   if (!!this.policy.reconnect) {
@@ -157,20 +159,54 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
     self._connection.on(Connection.Connected, function(c) {
       debug('connected');
       self.emit(AMQPClient.ConnectionOpened);
+
+      var promises = [];
+      
+      // Only map the session if it has already been created
       if (self._session) {
         debug('session already exists, re-using');
         self._session.connection = self._connection;
-      } else {
-        self._session = self._newSession(c);
+
+        promises.push(new Promise(function(resolve, reject) {
+          self._session.once(Session.Mapped, function(s) {
+            debug('client session mapped');
+            resolve();
+          });
+
+          self._session.begin(pu.Merge(self.policy.session, self._session.policy));
+        }));
       }
 
-      self._session.once(Session.Mapped, function(s) {
-        debug('mapped');
+      // Update any user-generated sessions
+      promises = promises.concat(self._userSessions.map(function(session) {
+        session.connection = self._connection;
+
+        return new Promise(function(resolve, reject) {
+          session.once(Session.Mapped, function(s) {
+            debug('user session mapped');
+            resolve();
+          });
+          
+          // We specifically don't merge the policies here because the policy
+          // for these sessions is passed in explicitly on create of the
+          // session. It's very unlikely that there wouldn't be a policy for the
+          // session at this point, but we fall back to the session policy from
+          // the client just in case. That being said, the policy specified
+          // explicitly by the user for that session should take precendence,
+          // leading to the lack of a merge here.
+          session.begin(session.policy || self.policy.session);
+        });
+      }));
+
+      if (promises.length > 0) {
+        Promise.all(promises).then(function() {
+          self.emit('connected');
+          resolve(self); 
+        }).catch(reject);
+      } else {
         self.emit('connected');
         resolve(self);
-      });
-
-      self._session.begin(self.policy.session);
+      }
     });
 
     self._connection.on(Connection.Disconnected, function() {
@@ -195,6 +231,35 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
 };
 
 /**
+ * Creates a session for the current connection that can be associated with any
+ * new links on that connection
+ *
+ * @inner @memberof AMQPClient
+ *
+ * @return {Promise<Session>}
+ */
+AMQPClient.prototype.createSession = function(policyOverrides) {
+  if (!this._connection) {
+    throw new Error('Must connect before creating sessions');
+  }
+
+  policyOverrides = policyOverrides || {};
+
+  var session = this._newSession(this._connection);
+  this._userSessions.push(session);
+
+  var self = this;
+  return new Promise(function (resolve, reject) {
+    session.once(Session.Mapped, function() {
+      debug('user session mapped');
+      resolve(session);
+    });
+
+    session.begin(pu.Merge(policyOverrides, self.policy.session));
+  });
+};
+
+/**
  * Creates a sender link for the given address, with optional link policy
  *
  * @inner @memberof AMQPClient
@@ -204,7 +269,7 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
  *
  * @return {Promise<SenderLink>}
  */
-AMQPClient.prototype.createSender = function(address, policyOverrides) {
+AMQPClient.prototype.createSender = function(address, policyOverrides, session) {
   if (!this._connection) {
     throw new Error('Must connect before creating links');
   }
@@ -229,19 +294,20 @@ AMQPClient.prototype.createSender = function(address, policyOverrides) {
     linkPolicy.defaultSubject = address.subject;
   }
 
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    var attach = function() {
-      var attachPromise = function(_err, _link) {
-        if (!!_err) return reject(_err);
-        return resolve(_link);
+  return this._getSession(session).then(function (session) {
+    return new Promise(function(resolve, reject) {
+      var attach = function() {
+        var attachPromise = function(_err, _link) {
+          if (!!_err) return reject(_err);
+          return resolve(_link);
+        };
+
+        var link = session.createLink(linkPolicy);
+        link._onAttach.push(attachPromise);
       };
 
-      var link = self._session.createLink(linkPolicy);
-      link._onAttach.push(attachPromise);
-    };
-
-    attach();
+      attach();
+    });
   });
 };
 
@@ -254,8 +320,8 @@ AMQPClient.prototype.createSender = function(address, policyOverrides) {
  *
  * @return {Promise<SenderStream>}
  */
-AMQPClient.prototype.createSenderStream = function(address, policyOverrides) {
-  return this.createSender(address, policyOverrides)
+AMQPClient.prototype.createSenderStream = function(address, policyOverrides, session) {
+  return this.createSender(address, policyOverrides, session)
     .then(function(link) { return new SenderStream(link, policyOverrides); });
 };
 
@@ -271,7 +337,7 @@ AMQPClient.prototype.createSenderStream = function(address, policyOverrides) {
  *
  * @return {Promise<ReceiverLink>}
  */
-AMQPClient.prototype.createReceiver = function(address, policyOverrides) {
+AMQPClient.prototype.createReceiver = function(address, policyOverrides, session) {
   if (!this._connection) {
     throw new Error('Must connect before creating links');
   }
@@ -304,19 +370,20 @@ AMQPClient.prototype.createReceiver = function(address, policyOverrides) {
       translator(['described', ['symbol', filterSymbol], ['string', address.subject]]);
   }
 
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    var attach = function() {
-      var attachPromise = function(_err, _link) {
-        if (!!_err) return reject(_err);
-        return resolve(_link);
+  return this._getSession(session).then(function (session) {
+    return new Promise(function(resolve, reject) {
+      var attach = function() {
+        var attachPromise = function(_err, _link) {
+          if (!!_err) return reject(_err);
+          return resolve(_link);
+        };
+
+        var link = session.createLink(linkPolicy);
+        link._onAttach.push(attachPromise);
       };
 
-      var link = self._session.createLink(linkPolicy);
-      link._onAttach.push(attachPromise);
-    };
-
-    attach();
+      attach();
+    });
   });
 };
 
@@ -329,14 +396,14 @@ AMQPClient.prototype.createReceiver = function(address, policyOverrides) {
  *
  * @return {Promise<ReceiverStream>}
  */
-AMQPClient.prototype.createReceiverStream = function(address, policyOverrides) {
+AMQPClient.prototype.createReceiverStream = function(address, policyOverrides, session) {
   // Override default credit behavior, as the stream will handle flow. The
   // creditQuantum will be used as the stream's highWatermark by default.
   policyOverrides = u.deepMerge({
     credit: function() {},
   }, policyOverrides || {});
 
-  return this.createReceiver(address, policyOverrides)
+  return this.createReceiver(address, policyOverrides, session)
     .then(function(link) { return new ReceiverStream(link); });
 };
 
@@ -369,6 +436,46 @@ AMQPClient.prototype.disconnect = function() {
   });
 };
 
+// Use the provided session, falling back to the client's session and creating
+// it if it doesn't already exist
+AMQPClient.prototype._getSession = function(session) {
+  // Just return the provided session if one was passed in
+  if (session) {
+    return Promise.resolve(session);
+  }
+
+  var self = this;
+  if (this._session) {
+    if (!this._session.mapping) {
+      // If we have a client session and it's not being mapped, return it
+      return Promise.resolve(this._session);
+    } else {
+      // If we have a client and it's currently mapping, wait for it to be mapped
+      // and then return it
+      return new Promise(function (resolve, reject) {
+        self._session.once(Session.Mapped, function() {
+          resolve(self._session);
+        });
+      });
+    }
+  }
+
+  if (!this._connection) {
+    throw new Error('Must connect before creating sessions');
+  }
+
+  this._session = this._newSession(this._connection);
+
+  return new Promise(function (resolve, reject) {
+    self._session.once(Session.Mapped, function() {
+      debug('client session mapped');
+      resolve(self._session);
+    });
+
+    self._session.begin(self.policy.session);
+  });
+};
+
 AMQPClient.prototype._clearConnectionState = function(saveReconnectDetails) {
   if (!!this._connection) this._connection.removeAllListeners();
   this._connection = null;
@@ -377,6 +484,9 @@ AMQPClient.prototype._clearConnectionState = function(saveReconnectDetails) {
   }
 
   if (this._session) this._session._resetLinkState();
+  this._userSessions.forEach(function (session) {
+    session._resetLinkState();
+  });
 };
 
 // Helper methods for mocking in tests.
@@ -395,7 +505,12 @@ AMQPClient.prototype._newSession = function(conn) {
   var self = this;
   var session = new Session(conn);
   session.on(Session.Unmapped, function(s) {
-    debug('unmapped');
+    debug('session unmapped');
+    if (session.disposed) {
+      session.removeAllListeners();
+      this._userSessions = this._userSessions.filter(function (s) { return s !== session; });
+      if (this._session === session) this._session = null;
+    }
   });
 
   session.on(Session.ErrorReceived, function(e) {

--- a/lib/policies/policy.js
+++ b/lib/policies/policy.js
@@ -110,6 +110,7 @@ function Policy(overrides) {
      * @property {function} window A function used to calculate how/when the flow control window should change
      * @property {number} windowQuantum Quantum used in predefined window policies
      * @property {boolean} enableSessionFlowControl Whether or not session flow control should be performed at all
+     * @property {object|null} reestablish=null Whether the session should attempt to reestablish when ended by the broker
      */
     session: {
       options: {
@@ -120,7 +121,8 @@ function Policy(overrides) {
 
       window: putils.WindowPolicies.RefreshAtHalf,
       windowQuantum: constants.session.defaultIncomingWindow,
-      enableSessionFlowControl: true
+      enableSessionFlowControl: true,
+      reestablish: null
     },
 
     /**

--- a/lib/policies/service_bus_policy.js
+++ b/lib/policies/service_bus_policy.js
@@ -3,6 +3,13 @@ var Policy = require('./policy');
 
 module.exports = new Policy({
   defaultSubjects: false,
+  session: {
+    reestablish: {
+      retries: 10,
+      strategy: 'fibonacci', // || 'exponential'
+      forever: true
+    }
+  },
   senderLink: {
     attach: {
       maxMessageSize: 10000, // Arbitrary choice

--- a/lib/session.js
+++ b/lib/session.js
@@ -125,6 +125,7 @@ function Session(conn) {
   this._senderLinks = {};
   this._receiverLinks = {};
   this._linksByRemoteHandle = {};
+  this._disposed = false;
 
   var self = this;
   this.sm = new StateMachine(stateMachine(this));
@@ -148,11 +149,23 @@ Session.ErrorReceived = 'errorReceived';
 // delivery-ids involved, whether they were settled, and the state.
 Session.DispositionReceived = 'disposition';
 
+Object.defineProperty(Session.prototype, 'mapping', {
+  get: function() { return this.sm.getMachineState() === 'BEGIN_SENT'; }
+});
+
+Object.defineProperty(Session.prototype, 'disposed', {
+  get: function() { return this._disposed; }
+});
+
 Session.prototype.begin = function(sessionPolicy) {
   var sessionParams = u.deepCopy(sessionPolicy.options);
   u.assertArguments(sessionParams, ['nextOutgoingId', 'incomingWindow', 'outgoingWindow']);
 
   this.policy = sessionPolicy;
+  if (this.policy.reestablish) {
+    this._timeouts = u.generateTimeouts(this.policy.reestablish);
+  }
+
   this.channel = this.connection.associateSession(this);
   this._sessionParams = sessionParams;
   this._initialOutgoingId = sessionParams.nextOutgoingId;
@@ -189,8 +202,8 @@ Session.prototype.createLink = function(linkPolicy) {
 
   var self = this;
   link.on(Link.Detached, function(details) {
-    debug('detached(' + this.name + '): ' + (details ? details.error : 'No details'));
-    if (!this.shouldReattach()) self._removeLink(this);
+    debug('detached(' + link.name + '): ' + (details ? details.error : 'No details'));
+    if (!link.shouldReattach() || self.disposed) self._removeLink(link);
   });
 
   link.on(Link.ErrorReceived, function(err) {
@@ -240,7 +253,11 @@ Session.prototype.detachLink = function(link) {
   return link.detach();
 };
 
-Session.prototype.end = function() {
+Session.prototype.end = function(options) {
+  options = options || { dispose: false };
+
+  if (options.dispose) this._disposed = true;
+  if (this._reestablishTimer) clearTimeout(this._reestablishTimer);
   if (this.remoteChannel !== undefined) {
     this.sm.sendEnd();
     this._sendEnd();
@@ -268,8 +285,10 @@ Session.prototype._processFrame = function(frame) {
     return;
   }
 
-  if (frame.channel === undefined || frame.channel !== this.remoteChannel) {
+  if (frame.channel === undefined) {
     debug('invalid frame: ', frame);
+    return;
+  } else if (frame.channel !== this.remoteChannel) {
     return;
   }
 
@@ -290,6 +309,15 @@ Session.prototype._processEndFrame = function(frame) {
   if (this.sm.getMachineState() !== 'UNMAPPED') {
     this.sm.sendEnd();
     this._sendEnd();
+
+    // Re-establish the session if the end was initiated by the broker
+    // and the policy indicates we should
+    if (this._shouldReestablish()) {
+      var self = this;
+      this.once(Session.Unmapped, function () {
+        self._attemptReestablish();
+      });
+    }
   }
 
   this._unmap();
@@ -411,7 +439,6 @@ Session.prototype._unmap = function() {
   if (this.connection !== undefined && this.channel !== undefined) {
     this.connection.removeListener(Connection.FrameReceived, this._processFrameEH);
     this.connection.dissociateSession(this.channel);
-    this.connection = undefined;
     this.remoteChannel = undefined;
     this.channel = undefined;
     this.mapped = false;
@@ -449,9 +476,33 @@ Session.prototype._processDispositionFrame = function(frame) {
  * Resets the state of all known links for this session.
  */
 Session.prototype._resetLinkState = function() {
-  var forceDetachLink = function(l) { l.forceDetach(); };
+  var self = this;
+  var forceDetachLink = function(l) { 
+    l.forceDetach();
+    if (self.disposed) self._removeLink(l);
+  };
   u.values(this._senderLinks).forEach(forceDetachLink);
   u.values(this._receiverLinks).forEach(forceDetachLink);
+};
+
+Session.prototype._shouldReestablish = function() {
+  return this._timeouts && (this._timeouts.length || this.policy.reestablish.forever);
+};
+
+Session.prototype._attemptReestablish = function() {
+  if (!this._timeouts.length) {
+    this._timeouts = u.generateTimeouts(this.policy.reestablish);
+  }
+
+  var self = this;
+  this._reestablishTimer = setTimeout(function() {
+    if (self._shouldReestablish() && self.connection.connected) {
+      debug('attempting to re-establish session');
+      self.begin(self.policy);
+    } else {
+      process.nextTick(function() { self._attemptReestablish(); });
+    }
+  }, this._timeouts.shift());
 };
 
 module.exports = Session;

--- a/test/integration/qpid/client.test.js
+++ b/test/integration/qpid/client.test.js
@@ -217,15 +217,13 @@ describe('Client', function() {
     var clientA = new AMQPClient(Policy.ActiveMQ),
         clientB = new AMQPClient(Policy.ActiveMQ);
     return Promise.all([ clientA.connect(config.address), clientB.connect(config.address) ])
-      .then(function() {
+      .then(function() { return Promise.all([ clientA.createSender('amq.topic'), clientB.createSender('amq.topic') ]); })
+      .spread(function(senderA, senderB) {
         expect(clientA._session.policy.options.outgoingWindow).to.eql(100);
         expect(clientB._session.policy.options.outgoingWindow).to.eql(100);
         expect(Policy.ActiveMQ.session.options.outgoingWindow).to.eql(100);
         expect(clientA._session._sessionParams.outgoingWindow).to.eql(100);
         expect(clientB._session._sessionParams.outgoingWindow).to.eql(100);
-        return Promise.all([ clientA.createSender('amq.topic'), clientB.createSender('amq.topic') ]);
-      })
-      .spread(function(senderA, senderB) {
         return Promise.all([
           senderA.send({ test: 'data' }), senderA.send({ test: 'data' }), senderB.send({ test: 'data' })
         ]);

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -8,6 +8,7 @@ var _ = require('lodash'),
     AMQPClient = require('../../lib').Client,
     MockServer = require('./mocks').Server,
 
+    Session = require('../../lib/session'),
     errors = require('../../lib/errors'),
     constants = require('../../lib/constants'),
     frames = require('../../lib/frames'),
@@ -82,11 +83,6 @@ describe('Client', function() {
       test.server.setResponseSequence([
         constants.amqpVersion,
         new frames.OpenFrame(test.client.policy.connect.options),
-        new frames.BeginFrame({
-          remoteChannel: 1, nextOutgoingId: 0,
-          incomingWindow: 2147483647, outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
         new frames.CloseFrame({
           error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
         })
@@ -300,18 +296,13 @@ describe('Client', function() {
       test.server.setResponseSequence([
         constants.amqpVersion,
         new frames.OpenFrame({ containerId: 'server' }),
-        new frames.BeginFrame({
-          remoteChannel: 1, nextOutgoingId: 0,
-          incomingWindow: 2147483647, outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
         new frames.CloseFrame({
           error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
         })
       ]);
 
       return test.client.connect(test.server.address())
-        .then(function() {
+        .then(function () {
           expect(test.client._connection.remote.open.idleTimeout).to.equal(constants.defaultIdleTimeout);
           return test.client.disconnect();
         });
@@ -321,11 +312,6 @@ describe('Client', function() {
       test.server.setResponseSequence([
         constants.amqpVersion,
         new frames.OpenFrame({ containerId: 'server', idleTimeout: 57 }),
-        new frames.BeginFrame({
-          remoteChannel: 1, nextOutgoingId: 0,
-          incomingWindow: 2147483647, outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
         new frames.CloseFrame({
           error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
         })
@@ -343,11 +329,6 @@ describe('Client', function() {
       test.server.setResponseSequence([
         constants.amqpVersion,
         new frames.OpenFrame({ containerId: 'server', idleTimeout: 0 }),
-        new frames.BeginFrame({
-          remoteChannel: 1, nextOutgoingId: 0,
-          incomingWindow: 2147483647, outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
         new frames.CloseFrame({
           error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
         })
@@ -365,11 +346,6 @@ describe('Client', function() {
       test.server.setResponseSequence([
         constants.amqpVersion,
         new frames.OpenFrame({ containerId: 'server', idleTimeout: 0 }),
-        new frames.BeginFrame({
-          remoteChannel: 1, nextOutgoingId: 0,
-          incomingWindow: 2147483647, outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
         new frames.CloseFrame({
           error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
         })
@@ -517,6 +493,7 @@ describe('Client', function() {
 
       return test.server.teardown()
         .then(function() { return test.client.connect(address); })
+        .then(function() { return test.client.createSession(); })
         .then(function() { return test.client.disconnect(); });
     });
 
@@ -525,20 +502,10 @@ describe('Client', function() {
         // first connect
         constants.amqpVersion,
         new frames.OpenFrame(test.client.policy.connect.options),
-        new frames.BeginFrame({
-          remoteChannel: 1, nextOutgoingId: 0,
-          incomingWindow: 2147483647, outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
 
         // second connect
         constants.amqpVersion,
         new frames.OpenFrame(test.client.policy.connect.options),
-        new frames.BeginFrame({
-          remoteChannel: 1, nextOutgoingId: 0,
-          incomingWindow: 2147483647, outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
         new frames.CloseFrame({
           error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
         })
@@ -556,7 +523,52 @@ describe('Client', function() {
         .delay(250) // simulate some time to reconnect
         .then(function() { return test.client.disconnect(); });
     });
+  });
 
+  describe('#createSession()', function() {
+    beforeEach(function() {
+      if (!!test.server) test.server = undefined;
+      if (!!test.client) test.client = undefined;
+      test.client = new AMQPClient(TestPolicy);
+      test.server = new MockServer();
+      return test.server.setup();
+    });
+
+    afterEach(function() {
+      if (!test.server) return;
+      return test.server.teardown()
+        .then(function() {
+          test.server = undefined;
+        });
+    });
+
+    it('should create a new session', function() {
+      test.server.setResponseSequence([
+        constants.amqpVersion,
+        new frames.OpenFrame(test.client.policy.connect.options),
+        new frames.BeginFrame({
+          remoteChannel: 1, nextOutgoingId: 0,
+          incomingWindow: 2147483647, outgoingWindow: 2147483647,
+          handleMax: 4294967295
+        }),
+        new frames.CloseFrame({
+          error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
+        })
+      ]);
+
+      return test.client.connect(test.server.address())
+        .then(function() { return test.client.createSession(); })
+        .then(function(session) {
+          expect(session.mapped).to.be.true;
+          return test.client.disconnect();
+        });
+    });
+    
+    it('should fail if the client hasn\'t been connected yet', function() {
+      expect(function() {
+        return test.client.createSession();
+      }).to.throw();
+    });
   });
 
   describe('#reattach', function() {
@@ -630,6 +642,128 @@ describe('Client', function() {
         .then(function() {
           expect(receiver.state()).to.eql('detached');
         });
+    });
+  });
+
+  describe('#reconnect', function() {
+    beforeEach(function() {
+      if (!!test.server) test.server = undefined;
+      if (!!test.client) test.client = undefined;
+      test.client = new AMQPClient(TestPolicy, {
+        reconnect: { retries: 5, forever: true }
+      });
+
+      test.server = new MockServer();
+      return test.server.setup();
+    });
+
+    afterEach(function() {
+      if (!test.server) return;
+      return test.server.teardown()
+        .then(function() {
+          test.server = undefined;
+        });
+    });
+
+    it('should wait for all existing sessions to be mapped before completing', function(done) {
+      test.server.setResponseSequence([
+        constants.amqpVersion,
+        new frames.OpenFrame(test.client.policy.connect.options),
+        new frames.BeginFrame({
+          remoteChannel: 1, nextOutgoingId: 0,
+          incomingWindow: 2147483647, outgoingWindow: 2147483647,
+          handleMax: 4294967295
+        }),
+        new AttachFrameWithReceivedName(constants.linkRole.sender),
+        new frames.BeginFrame({
+          remoteChannel: 2, nextOutgoingId: 0,
+          incomingWindow: 2147483647, outgoingWindow: 2147483647,
+          handleMax: 4294967295
+        }),
+        [
+          new frames.BeginFrame({
+            remoteChannel: 3, nextOutgoingId: 0,
+            incomingWindow: 2147483647, outgoingWindow: 2147483647,
+            handleMax: 4294967295
+          }),
+          new frames.CloseFrame({
+            error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
+          }),
+        ]
+      ]);
+
+      // Set up a new server to connect to on disconnect
+      test.client.once('disconnected', function() {
+        setImmediate(function() {
+          test.server.teardown();
+          test.server = new MockServer();
+          test.server.setup();
+          test.server.setResponseSequence([
+            constants.amqpVersion,
+            new frames.OpenFrame(test.client.policy.connect.options),
+            [
+              new frames.BeginFrame({
+                remoteChannel: 1, nextOutgoingId: 0,
+                incomingWindow: 2147483647, outgoingWindow: 2147483647,
+                handleMax: 4294967295
+              }),
+              new frames.BeginFrame({
+                remoteChannel: 2, nextOutgoingId: 0,
+                incomingWindow: 2147483647, outgoingWindow: 2147483647,
+                handleMax: 4294967295
+              }),
+              new frames.BeginFrame({
+                remoteChannel: 3, nextOutgoingId: 0,
+                incomingWindow: 2147483647, outgoingWindow: 2147483647,
+                handleMax: 4294967295
+              })
+            ]
+          ]);
+        });
+      });
+
+      test.client.connect(test.server.address())
+        .then(function() {
+          var clientSession;
+          var session1;
+          var session2;
+          return test.client.createReceiver('testing')
+            .then(function(link) {
+              clientSession = link.session;
+              return test.client.createSession();
+            })
+            .then(function(session) {
+              session1 = session;
+              return test.client.createSession();
+            })
+            .then(function(session) {
+              session2 = session;
+              return [clientSession, session1, session2];
+            });
+        })
+        .spread(function(clientSession, session1, session2) {
+          var mapped = { clientSession: 0, session1: 0, session2: 0 };
+
+          clientSession.once(Session.Mapped, function() {
+            mapped.clientSession++;
+          });
+
+          session1.once(Session.Mapped, function() {
+            mapped.session1++;
+          });
+
+          session2.once(Session.Mapped, function() {
+            mapped.session2++;
+          });
+
+          test.client.once('connected', function() {
+            expect(mapped.clientSession).to.equal(1);
+            expect(mapped.session1).to.equal(1);
+            expect(mapped.session2).to.equal(1);
+            done();
+          });
+        })
+        .catch(done);
     });
   });
 });

--- a/test/unit/mock_amqp.js
+++ b/test/unit/mock_amqp.js
@@ -119,15 +119,21 @@ MockServer.prototype._testData = function() {
   while (this.buffer.length) {
     expect(this.requestsExpected.length).to.be.greaterThan(0, 'More data received than expected');
     var expected = this.requestsExpected[this.requestIdx];
+    if (expected instanceof Array) expected = expected[1];
     if (this.buffer.length < expected.length) return;
 
     expected = this.requestsExpected[this.requestIdx++];
+    if (expected instanceof Array) expected = expected[1];
     var actual = this.buffer.slice(0, expected.length);
     this.buffer.consume(expected.length);
 
     debug('Receiving ' + actual.toString('hex'));
     expect(actual.toString('hex')).to.eql(expected.toString('hex'), 'Req ' + (this.requestIdx - 1));
-    this._sendNext();
+    
+    // Send a frame if the next receive frame doesn't preempt it
+    if (!Array.isArray(this.requestsExpected[this.requestIdx]) || !this.requestsExpected[this.requestIdx][0]) {
+      this._sendNext();
+    }
   }
 };
 

--- a/test/unit/policies/policy.test.js
+++ b/test/unit/policies/policy.test.js
@@ -106,13 +106,6 @@ describe('Default Policy', function() {
       test.server.setResponseSequence([
         constants.amqpVersion,
         new frames.OpenFrame(policy.connect.options),
-        new frames.BeginFrame({
-          remoteChannel: 1,
-          nextOutgoingId: 0,
-          incomingWindow: 2147483647,
-          outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
         new frames.CloseFrame({
           error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
         })
@@ -153,13 +146,6 @@ describe('Default Policy', function() {
         new frames.SaslOutcomeFrame({code: constants.saslOutcomes.ok}),
         constants.amqpVersion,
         new frames.OpenFrame(policy.connect.options),
-        new frames.BeginFrame({
-          remoteChannel: 1,
-          nextOutgoingId: 0,
-          incomingWindow: 2147483647,
-          outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
         new frames.CloseFrame({
           error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
         })
@@ -189,13 +175,6 @@ describe('Default Policy', function() {
       test.server.setResponseSequence([
         constants.amqpVersion,
         new frames.OpenFrame(policy.connect.options),
-        new frames.BeginFrame({
-          remoteChannel: 1,
-          nextOutgoingId: 0,
-          incomingWindow: 2147483647,
-          outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
         new frames.CloseFrame({
           error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
         })

--- a/test/unit/policies/qpid_java.test.js
+++ b/test/unit/policies/qpid_java.test.js
@@ -57,11 +57,6 @@ describe('QpidJava Policy', function() {
         new frames.SaslOutcomeFrame({ code: constants.saslOutcomes.ok }),
         constants.amqpVersion,
         new frames.OpenFrame(amqp.Policy.QpidJava.connect.options),
-        new frames.BeginFrame({
-          remoteChannel: 1, nextOutgoingId: 0,
-          incomingWindow: 2147483647, outgoingWindow: 2147483647,
-          handleMax: 4294967295
-        }),
         new frames.CloseFrame({
           error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
         })


### PR DESCRIPTION
Addresses https://github.com/noodlefrenzy/node-amqp10/issues/331 by adding the ability to create multiple sessions on the same client/connection and providing policy options for reestablishing the session on end. This feature set is designed to better align the capabilities of amqp10 with the session pattern supported by Azure Service Bus and bring the retry logic inline with what is used for reattach and reconnect.

**Features**
 - [x] Add `createSession()` in `AMQPClient` to create user sessions
    - [x] Support custom policy overrides
 - [x] Allow an optional session to be passed in on `createSender()`, `createSenderStream()`, `createReceiver()`, `createReceiverStream()`
 - [x] Create the default session associated with the client only when needed
 - [x] `restart` policy option for reestablishing the session after it is ended

**Tests**
 - [x] `createSession()`
 - [x] Optional session parameter for `createSender()`, `createSenderStream()`, `createReceiver()`, `createReceiverStream()`
 - [x] Creating default client session on demand
 - [x] Session policy - `restart`

Please take a look and let me know what you think of the change. I'm open to changing the design/approach if people have other thoughts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/332)
<!-- Reviewable:end -->
