### PR TITLE
Extract SASL mechanisms in their own classes

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -126,9 +126,10 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
     self._defaultQueue = address.path.substr(1);
     connectPolicy.options.hostname = address.host;
     var saslMechanism = connectPolicy.saslMechanism;
+    var saslHandler = connectPolicy.saslHandler;
     var sasl = null;
     if (saslMechanism) {
-      if (!u.includes(Sasl.Mechanism, saslMechanism)) {
+      if (!u.includes(Sasl.Mechanism, saslMechanism) && saslHandler) {
         throw new errors.NotImplementedError(
           saslMechanism + ' is not a supported saslMechanism policy');
       }
@@ -141,7 +142,7 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
         throw new errors.AuthenticationError(
             'Sasl PLAIN requested, but no credentials provided in endpoint URI');
       } else {
-        sasl = new Sasl(saslMechanism);
+        sasl = new Sasl(saslMechanism, saslHandler);
       }
     } else if (address.user) {
       // force SASL plain if no mechanism specified, but creds in URI

--- a/lib/sasl/index.js
+++ b/lib/sasl/index.js
@@ -1,14 +1,14 @@
 'use strict';
 
 var debug = require('debug')('amqp10:sasl'),
-    Builder = require('buffer-builder'),
+    constants = require('../constants'),
+    frames = require('../frames'),
+    errors = require('../errors'),
+    u = require('../utilities'),
 
-    constants = require('./constants'),
-    frames = require('./frames'),
-    errors = require('./errors'),
-    u = require('./utilities'),
-
-    Connection = require('./connection');
+    Connection = require('../connection'),
+    SaslPlain = require('./sasl_plain'),
+    SaslAnonymous = require('./sasl_anonymous');
 
 var saslMechanism = {
   PLAIN: 'PLAIN',
@@ -16,17 +16,25 @@ var saslMechanism = {
   NONE: 'NONE'
 };
 
+var saslHandlers  = {
+  PLAIN: SaslPlain,
+  ANONYMOUS: SaslAnonymous
+};
+
 /**
  * Currently, only supports SASL ANONYMOUS or PLAIN
  *
  * @constructor
  */
-function Sasl(mechanism) {
-  if (mechanism && !u.includes(saslMechanism, mechanism)) {
+function Sasl(mechanism, handler) {
+  if (mechanism && !u.includes(saslMechanism, mechanism) && !handler) {
     throw new errors.NotImplementedError(
       'Only SASL PLAIN and ANONYMOUS are supported.');
   }
   this.mechanism = mechanism;
+  if (this.mechanism) {
+    this.handler = handler || new saslHandlers[mechanism]();
+  }
   this.receivedHeader = false;
 }
 
@@ -35,8 +43,13 @@ Sasl.Mechanism = saslMechanism;
 Sasl.prototype.negotiate = function(connection, credentials, done) {
   this.connection = connection;
   this.credentials = credentials;
-  if (this.credentials.user && this.credentials.pass && !this.mechanism) {
-    this.mechanism = Sasl.Mechanism.PLAIN;
+  if (this.credentials.user && this.credentials.pass) {
+    if  (!this.mechanism || this.mechanism === Sasl.Mechanism.PLAIN) {
+      this.mechanism = Sasl.Mechanism.PLAIN;
+      this.handler = new SaslPlain(this.credentials.user, this.credentials.pass);
+    } else if (this.mechanism === Sasl.Mechanism.ANONYMOUS) {
+      debug('warning: user and password specified when using SASL_ANONYMOUS');
+    }
   }
   this.callback = done;
   var self = this;
@@ -60,8 +73,8 @@ Sasl.prototype.headerReceived = function(header) {
 };
 
 Sasl.prototype._processFrame = function(frame) {
+  var self = this;
   if (frame instanceof frames.SaslMechanismsFrame) {
-    var buf = new Builder();
     var mechanism = this.mechanism;
     var mechanisms = Array.isArray(frame.saslServerMechanisms) ?
       frame.saslServerMechanisms.map(function(m) { return m.value; }) : frame.saslServerMechanisms;
@@ -69,32 +82,28 @@ Sasl.prototype._processFrame = function(frame) {
       this.callback(new errors.AuthenticationError(
         'SASL ' + mechanism + ' not supported by remote.'));
     }
-    if (mechanism === Sasl.Mechanism.PLAIN) {
-      debug('Sending ' + this.credentials.user + ':' + this.credentials.pass);
-      buf.appendUInt8(0); // <null>
-      buf.appendString(this.credentials.user);
-      buf.appendUInt8(0); // <null>
-      buf.appendString(this.credentials.pass);
-    } else if (mechanism === Sasl.Mechanism.ANONYMOUS) {
-      if (this.credentials.user && this.credentials.pass) {
-        console.warn(
-            'Sasl ANONYMOUS requested, but credentials provided in endpoint URI');
-      }
-      buf.appendUInt8(0); // <null>
-    } else {
-      this.callback(new errors.NotImplementedError(
-          'Only SASL PLAIN and ANONYMOUS are supported.'));
-    }
-    var initFrame = new frames.SaslInitFrame({
-      mechanism: mechanism,
-      initialResponse: buf.get()
-    });
 
-    if (!!this._remoteHostname) initFrame.hostname = this._remoteHostname;
-    this.connection.sendFrame(initFrame);
+    if (mechanism === Sasl.Mechanism.ANONYMOUS && this.credentials.user && this.credentials.pass) {
+      console.warn(
+          'Sasl ANONYMOUS requested, but credentials provided in endpoint URI');
+    }
+
+    this.handler.getInitFrame()
+      .then(function (initFrame) {
+        if (!!self._remoteHostname) initFrame.hostname = self._remoteHostname;
+        self.connection.sendFrame(initFrame);
+      })
+      .catch(function (err) {
+        self.callback(new errors.AuthenticationError('SASL Init Failed: ' + frame.code + ': ' + frame.details + ' with error: ' + err.toString()));
+      });
   } else if (frame instanceof frames.SaslChallengeFrame) {
-    var responseFrame = new frames.SaslResponseFrame({});
-    this.connection.sendFrame(responseFrame);
+    this.handler.getChallengeResponse(frame)
+      .then((responseFrame) => {
+        self.connection.sendFrame(responseFrame);
+      })
+      .catch((err) => {
+        self.callback(new errors.AuthenticationError('SASL Challenge Failed: ' + frame.code + ': ' + frame.details + ' with error: ' + err.toString()));
+      });
   } else if (frame instanceof frames.SaslOutcomeFrame) {
     if (frame.code === constants.saslOutcomes.ok) {
       this.callback();

--- a/lib/sasl/sasl_anonymous.js
+++ b/lib/sasl/sasl_anonymous.js
@@ -1,0 +1,30 @@
+'use strict';
+var Promise = require('bluebird'),
+    frames = require('../frames'),
+    Builder = require('buffer-builder');
+
+function SaslAnonymous () {
+
+}
+
+SaslAnonymous.prototype.getInitFrame = function() {
+  return new Promise(function(resolve) {
+    var buf = new Builder();
+    buf.appendUInt8(0); // <null>
+
+    var initFrame = new frames.SaslInitFrame({
+      mechanism: 'ANONYMOUS',
+      initialResponse: buf.get()
+    });
+
+    resolve(initFrame);
+  });
+};
+
+SaslAnonymous.prototype.getChallengeResponse = function (frame) {
+  return new Promise(function(resolve) {
+    resolve(new frames.SaslResponseFrame({}));
+  });
+};
+
+module.exports = SaslAnonymous;

--- a/lib/sasl/sasl_plain.js
+++ b/lib/sasl/sasl_plain.js
@@ -1,0 +1,35 @@
+'use strict';
+var frames = require('../frames'),
+    Builder = require('buffer-builder'),
+    Promise = require('bluebird');
+
+function SaslPlain (user, password) {
+  this._user = user;
+  this._password = password;
+}
+
+SaslPlain.prototype.getInitFrame = function () {
+  var self = this;
+  return new Promise(function(resolve) {
+    var buf = new Builder();
+    buf.appendUInt8(0); // <null>
+    buf.appendString(self._user);
+    buf.appendUInt8(0); // <null>
+    buf.appendString(self._password);
+
+    var initFrame = new frames.SaslInitFrame({
+      mechanism: 'PLAIN',
+      initialResponse: buf.get()
+    });
+
+    resolve(initFrame);
+  });
+};
+
+SaslPlain.prototype.getChallengeResponse = function (frame) {
+  return new Promise(function(resolve) {
+    resolve(new frames.SaslResponseFrame({}));
+  });
+};
+
+module.exports = SaslPlain;


### PR DESCRIPTION
The ultimate goal of this pull-request is to provide a way for users of the library to create their own SASL mechanisms that would reply to complex challenge/response scenarios.

The first commit only to show the direction I'm suggesting and maybe get some early feedback (I fully intend to write more tests if this direction is approved):
- Separate SASL_PLAIN and SASL_ANONYMOUS handlers in their own classes and use them from the main `Sasl` object.
- add a `saslHandler` field to the connect policy that would allow a user to pass a custom Sasl challenge/response handler.
- the new classes use async methods because in the case of the sasl challenge/response scenario, there are cases where the code computing the response to the challenge will be asynchronous.

One thing that bothers me is that the SASL objects right now manipulate frames which are believe are not exported from the library - we could change that to only manipulate buffers though, or decide to extract the frame objects.

The last option would be to accept implementation of custom SASL mechanisms in the repository of course.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/346)
<!-- Reviewable:end -->
