### PR TITLE
Separate SASL mechanism and add "registerSaslMechanism" API on the client

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -5,7 +5,9 @@ var EventEmitter = require('events').EventEmitter,
     util = require('util'),
 
     Connection = require('./connection'),
-    Sasl = require('./sasl'),
+    Sasl = require('./sasl/sasl'),
+    SaslPlain = require('./sasl/sasl_plain'),
+    SaslAnonymous = require('./sasl/sasl_anonymous'),
     Session = require('./session'),
     ReceiverStream = require('./streams/receiver_stream'),
     SenderStream = require('./streams/sender_stream'),
@@ -65,7 +67,7 @@ function AMQPClient(policy, policyOverrides) {
     this.policy = policy || new Policy();
     if (!!policyOverrides) this.policy = pu.Merge(policyOverrides, this.policy);
   }
-
+  this.saslHandlers = {};
   this._connection = null;
   this._session = null;
   this._sessionPromise = null;
@@ -130,7 +132,7 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
     var saslMechanism = connectPolicy.saslMechanism;
     var sasl = null;
     if (saslMechanism) {
-      if (!u.includes(Sasl.Mechanism, saslMechanism)) {
+      if (!u.includes(Sasl.Mechanism, saslMechanism) && !self.saslHandlers[saslMechanism]) {
         throw new errors.NotImplementedError(
           saslMechanism + ' is not a supported saslMechanism policy');
       }
@@ -143,12 +145,21 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
         throw new errors.AuthenticationError(
             'Sasl PLAIN requested, but no credentials provided in endpoint URI');
       } else {
-        sasl = new Sasl(saslMechanism);
+        if (self.saslHandlers[saslMechanism]) {
+          sasl = new Sasl(saslMechanism, self.saslHandlers[saslMechanism]);
+        } else if (saslMechanism === Sasl.Mechanism.ANONYMOUS) {
+            sasl = new Sasl(Sasl.Mechanism.ANONYMOUS, new SaslAnonymous());
+        } else if (saslMechanism === Sasl.Mechanism.PLAIN) {
+          sasl = new Sasl(Sasl.Mechanism.PLAIN, new SaslPlain());
+        } else {
+          throw new errors.AuthenticationError(
+            'No adequate SASL handler for the requested mechanism');
+        }
       }
     } else if (address.user) {
       // force SASL plain if no mechanism specified, but creds in URI
       connectPolicy.saslMechanism = Sasl.Mechanism.PLAIN;
-      sasl = new Sasl(Sasl.Mechanism.PLAIN);
+      sasl = new Sasl(Sasl.Mechanism.PLAIN, new SaslPlain());
     }
     if (!!sasl && !!address.vhost) {
       sasl._remoteHostname = address.vhost;
@@ -161,7 +172,7 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
       self.emit(AMQPClient.ConnectionOpened);
 
       var promises = [];
-      
+
       // Only map the session if it has already been created
       if (self._session) {
         debug('session already exists, re-using');
@@ -186,7 +197,7 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
             debug('user session mapped');
             resolve();
           });
-          
+
           // We specifically don't merge the policies here because the policy
           // for these sessions is passed in explicitly on create of the
           // session. It's very unlikely that there wouldn't be a policy for the
@@ -201,7 +212,7 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
       if (promises.length > 0) {
         Promise.all(promises).then(function() {
           self.emit('connected');
-          resolve(self); 
+          resolve(self);
         }).catch(reject);
       } else {
         self.emit('connected');
@@ -434,6 +445,17 @@ AMQPClient.prototype.disconnect = function() {
       resolve(); // Already disconnected, just deliver the promise.
     }
   });
+};
+
+/**
+ * Registers a new SASL mechanism to handle SASL challenges during authentication.
+ *
+ * @param {string}      mechanism   Name of the mechanism used to authenticate - must match what the server sends in the SASL-Mechanism frame.
+ * @param {SaslHandler} handler     Object that is going to handle SASL challenges and craft corresponding responses.
+ */
+AMQPClient.prototype.registerSaslMechanism = function(mechanism, handler) {
+  Sasl.Mechanism[mechanism] = mechanism;
+  this.saslHandlers[mechanism] = handler;
 };
 
 // Use the provided session, falling back to the client's session and creating

--- a/lib/sasl/sasl.js
+++ b/lib/sasl/sasl.js
@@ -1,14 +1,11 @@
 'use strict';
 
 var debug = require('debug')('amqp10:sasl'),
-    Builder = require('buffer-builder'),
-
-    constants = require('./constants'),
-    frames = require('./frames'),
-    errors = require('./errors'),
-    u = require('./utilities'),
-
-    Connection = require('./connection');
+    constants = require('../constants'),
+    frames = require('../frames'),
+    errors = require('../errors'),
+    u = require('../utilities'),
+    Connection = require('../connection');
 
 var saslMechanism = {
   PLAIN: 'PLAIN',
@@ -21,12 +18,12 @@ var saslMechanism = {
  *
  * @constructor
  */
-function Sasl(mechanism) {
-  if (mechanism && !u.includes(saslMechanism, mechanism)) {
-    throw new errors.NotImplementedError(
-      'Only SASL PLAIN and ANONYMOUS are supported.');
+function Sasl(mechanism, handler) {
+  if (!mechanism || !handler) {
+    throw new errors.NotImplementedError('Need both the mechanism and the handler');
   }
   this.mechanism = mechanism;
+  this.handler = handler;
   this.receivedHeader = false;
 }
 
@@ -35,9 +32,6 @@ Sasl.Mechanism = saslMechanism;
 Sasl.prototype.negotiate = function(connection, credentials, done) {
   this.connection = connection;
   this.credentials = credentials;
-  if (this.credentials.user && this.credentials.pass && !this.mechanism) {
-    this.mechanism = Sasl.Mechanism.PLAIN;
-  }
   this.callback = done;
   var self = this;
   this._processFrameEH = function(frame) { self._processFrame(frame); };
@@ -60,8 +54,8 @@ Sasl.prototype.headerReceived = function(header) {
 };
 
 Sasl.prototype._processFrame = function(frame) {
+  var self = this;
   if (frame instanceof frames.SaslMechanismsFrame) {
-    var buf = new Builder();
     var mechanism = this.mechanism;
     var mechanisms = Array.isArray(frame.saslServerMechanisms) ?
       frame.saslServerMechanisms.map(function(m) { return m.value; }) : frame.saslServerMechanisms;
@@ -69,32 +63,41 @@ Sasl.prototype._processFrame = function(frame) {
       this.callback(new errors.AuthenticationError(
         'SASL ' + mechanism + ' not supported by remote.'));
     }
-    if (mechanism === Sasl.Mechanism.PLAIN) {
-      debug('Sending ' + this.credentials.user + ':' + this.credentials.pass);
-      buf.appendUInt8(0); // <null>
-      buf.appendString(this.credentials.user);
-      buf.appendUInt8(0); // <null>
-      buf.appendString(this.credentials.pass);
-    } else if (mechanism === Sasl.Mechanism.ANONYMOUS) {
-      if (this.credentials.user && this.credentials.pass) {
-        console.warn(
-            'Sasl ANONYMOUS requested, but credentials provided in endpoint URI');
-      }
-      buf.appendUInt8(0); // <null>
-    } else {
-      this.callback(new errors.NotImplementedError(
-          'Only SASL PLAIN and ANONYMOUS are supported.'));
-    }
-    var initFrame = new frames.SaslInitFrame({
-      mechanism: mechanism,
-      initialResponse: buf.get()
-    });
 
-    if (!!this._remoteHostname) initFrame.hostname = this._remoteHostname;
-    this.connection.sendFrame(initFrame);
+    if (mechanism === Sasl.Mechanism.ANONYMOUS && this.credentials.user && this.credentials.pass) {
+      console.warn(
+          'Sasl ANONYMOUS requested, but credentials provided in endpoint URI');
+    }
+
+    this.handler.getInitFrameContent(self.credentials)
+      .then(function (initFrameContent) {
+        var initFrame = new frames.SaslInitFrame({
+          mechanism: initFrameContent.mechanism,
+          initialResponse: initFrameContent.initialResponse,
+          hostname: initFrameContent.hostname
+        });
+
+        if (!!self._remoteHostname && self._remoteHostname !== initFrame.hostname) {
+          initFrame.hostname = self._remoteHostname;
+        }
+
+        self.connection.sendFrame(initFrame);
+      })
+      .catch(function (err) {
+        self.callback(new errors.AuthenticationError('SASL Init Failed: ' + frame.code + ': ' + frame.details + ' with error: ' + err.toString()));
+      });
   } else if (frame instanceof frames.SaslChallengeFrame) {
-    var responseFrame = new frames.SaslResponseFrame({});
-    this.connection.sendFrame(responseFrame);
+    this.handler.getChallengeResponseContent(frame.value)
+      .then((responseContent) => {
+        var responseFrame = responseContent ? new frames.SaslResponseFrame({
+          response: responseContent
+        }) : new frames.SaslResponseFrame({});
+
+        self.connection.sendFrame(responseFrame);
+      })
+      .catch((err) => {
+        self.callback(new errors.AuthenticationError('SASL Challenge Failed: ' + frame.code + ': ' + frame.details + ' with error: ' + err.toString()));
+      });
   } else if (frame instanceof frames.SaslOutcomeFrame) {
     if (frame.code === constants.saslOutcomes.ok) {
       this.callback();

--- a/lib/sasl/sasl_anonymous.js
+++ b/lib/sasl/sasl_anonymous.js
@@ -1,0 +1,24 @@
+'use strict';
+var Builder = require('buffer-builder'),
+    Promise = require('bluebird');
+
+function SaslAnonymous () {}
+
+SaslAnonymous.prototype.getInitFrameContent = function() {
+  return new Promise(function(resolve) {
+    var buf = new Builder();
+    buf.appendUInt8(0); // <null>
+    resolve({
+      mechanism: 'ANONYMOUS',
+      initialResponse: buf.get()
+    });
+  });
+};
+
+SaslAnonymous.prototype.getChallengeResponseContent = function () {
+  return new Promise(function(resolve) {
+    resolve();
+  });
+};
+
+module.exports = SaslAnonymous;

--- a/lib/sasl/sasl_plain.js
+++ b/lib/sasl/sasl_plain.js
@@ -1,0 +1,29 @@
+'use strict';
+var Builder = require('buffer-builder'),
+    Promise = require('bluebird');
+
+function SaslPlain () {
+}
+
+SaslPlain.prototype.getInitFrameContent = function (credentials) {
+  return new Promise(function(resolve) {
+    var buf = new Builder();
+    buf.appendUInt8(0); // <null>
+    buf.appendString(credentials.user);
+    buf.appendUInt8(0); // <null>
+    buf.appendString(credentials.pass);
+
+    resolve({
+      mechanism: 'PLAIN',
+      initialResponse: buf.get()
+    });
+  });
+};
+
+SaslPlain.prototype.getChallengeResponseContent = function () {
+  return new Promise(function(resolve) {
+    resolve();
+  });
+};
+
+module.exports = SaslPlain;

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -7,6 +7,7 @@ var _ = require('lodash'),
     Builder = require('buffer-builder'),
     AMQPClient = require('../../lib').Client,
     MockServer = require('./mocks').Server,
+    MockServerWithSasl = require('./mock_amqp'),
 
     Session = require('../../lib/session'),
     errors = require('../../lib/errors'),
@@ -563,7 +564,7 @@ describe('Client', function() {
           return test.client.disconnect();
         });
     });
-    
+
     it('should fail if the client hasn\'t been connected yet', function() {
       expect(function() {
         return test.client.createSession();
@@ -764,6 +765,102 @@ describe('Client', function() {
           });
         })
         .catch(done);
+    });
+  });
+
+  describe('#registerSaslMechanism()', function() {
+    beforeEach(function() {
+      if (!!test.server) test.server = undefined;
+      if (!!test.client) test.client = undefined;
+      test.client = new AMQPClient(TestPolicy);
+      test.server = new MockServerWithSasl();
+    });
+
+    afterEach(function(done) {
+      if (test.server) {
+        test.server.teardown();
+        test.server = null;
+      }
+      if (test.client) {
+        test.client = null;
+      }
+      done();
+    });
+
+    it('should use the registered Sasl mechanism when connecting', function (done) {
+      var saslMechanism = 'TEST';
+      var expectedChallenge = 'challenge';
+      var expectedChallengeResponse = 'challenge-response';
+      var expectedSaslInitResponse = 'init';
+
+      var initOK = false;
+      var challengeOK = false;
+
+      var expectedSaslInitFrame = new frames.SaslInitFrame({
+        mechanism: saslMechanism,
+        initialResponse: expectedSaslInitResponse
+      });
+
+      var expectedSaslChallengeResponseFrame = new frames.SaslResponseFrame({
+        response: expectedChallengeResponse
+      });
+
+      var saslHandler = {
+        getInitFrameContent: function() {
+          return new Promise(function(resolve) {
+            initOK = true;
+            resolve({
+              mechanism: saslMechanism,
+              initialResponse: expectedSaslInitResponse
+            });
+          });
+        },
+        getChallengeResponseContent: function(challengeFrame) {
+          return new Promise(function(resolve) {
+            challengeOK = true;
+            expect(challengeFrame[0].value.toString()).to.equal(expectedChallenge);
+            resolve(expectedChallengeResponse);
+          });
+        }
+      };
+
+      test.server.setSequence([
+        constants.saslVersion,
+        expectedSaslInitFrame,
+        expectedSaslChallengeResponseFrame,
+        constants.amqpVersion,
+        new frames.OpenFrame(test.client.policy.connect.options),
+        new frames.BeginFrame({ nextOutgoingId: 1, incomingWindow: 100, outgoingWindow: 100, channel: 1})
+      ], [
+        constants.saslVersion,
+        [ true, new frames.SaslMechanismsFrame({ saslServerMechanisms: [saslMechanism] }) ],
+        new frames.SaslChallengeFrame({
+          challenge: expectedChallenge
+        }),
+        new frames.SaslOutcomeFrame({ code: constants.saslOutcomes.ok }),
+        constants.amqpVersion,
+        new frames.OpenFrame(test.client.policy.connect.options),
+
+        new frames.BeginFrame({
+          remoteChannel: 1, nextOutgoingId: 0,
+          incomingWindow: 2147483647, outgoingWindow: 2147483647,
+          handleMax: 4294967295
+        })
+      ]);
+      test.server.setup();
+
+      // need both the policy setting and the registerSaslMechanism call to work (since one could in theory register multiple sasl mechanism but only one can be used to connect)
+      test.client.policy.connect.saslMechanism = saslMechanism;
+      test.client.registerSaslMechanism(saslMechanism, saslHandler);
+
+      test.client.connect('amqp://localhost:' + test.server.port)
+        .then(function () {
+          expect(initOK).to.equal(true);
+          expect(challengeOK).to.equal(true);
+          done();
+      }).catch(function(err) {
+        done(err);
+      });
     });
   });
 });

--- a/test/unit/policies/policy.test.js
+++ b/test/unit/policies/policy.test.js
@@ -6,7 +6,7 @@ var amqp = require('../../../lib'),
     constants = require('../../../lib/constants'),
     frames = require('../../../lib/frames'),
     errors = require('../../../lib/errors'),
-    Sasl = require('../../../lib/sasl'),
+    Sasl = require('../../../lib/sasl/sasl'),
     ErrorCondition = require('../../../lib/types/error_condition'),
 
     pu = require('../../../lib/policies/policy_utilities'),

--- a/test/unit/test_sasl.js
+++ b/test/unit/test_sasl.js
@@ -11,9 +11,12 @@ var builder = require('buffer-builder'),
     ErrorCondition = require('../../lib/types/error_condition'),
 
     Connection = require('../../lib/connection'),
-    Sasl = require('../../lib/sasl'),
+    Sasl = require('../../lib/sasl/sasl'),
+    SaslPlain = require('../../lib/sasl/sasl_plain'),
 
-    tu = require('./../testing_utils');
+    tu = require('./../testing_utils'),
+    errors = require('../../lib/errors'),
+    expect = require('chai').expect;
 
 function MockSaslInitFrame() {
   return new frames.SaslInitFrame({
@@ -29,6 +32,20 @@ var test = {
 };
 
 describe('Sasl', function() {
+  describe('constructor', function () {
+    it('should throw if the either the saslMechanism or saslHandler parameters are null', function () {
+      expect(function () {
+        return new Sasl();
+      }).to.throw(errors.NotImplementedError);
+      expect(function () {
+        return new Sasl('mechanism');
+      }).to.throw(errors.NotImplementedError);
+      expect(function () {
+        return new Sasl('', {});
+      }).to.throw(errors.NotImplementedError);
+    });
+  });
+
   describe('Connection.open()', function() {
     var server = null;
 
@@ -70,7 +87,76 @@ describe('Sasl', function() {
       ];
 
       connection.connSM.bind(tu.assertTransitions(expected, function() { done(); }));
-      connection.open({protocol: 'amqp',host: 'localhost', port: server.port, user: 'user', pass: 'pass'}, new Sasl());
+      connection.open({protocol: 'amqp', host: 'localhost', port: server.port, user: 'user', pass: 'pass'}, new Sasl('PLAIN', new SaslPlain()));
+    });
+
+    it('should use the saslHandler passed to the constructor for the init frame', function (done) {
+      var expectedSaslMechanism = 'TEST';
+      var expectedInitialAnswer = new Buffer('initialAnswer');
+      var expectedChallenge = new Buffer('challenge');
+      var expectedChallengeResponse = new Buffer('challenge-response');
+
+      var expectedSaslInitFrame = new frames.SaslInitFrame({
+        mechanism: expectedSaslMechanism,
+        initialResponse: expectedInitialAnswer
+      });
+
+      var expectedSaslChallengeResponseFrame = new frames.SaslResponseFrame({
+        response: expectedChallengeResponse
+      });
+
+      var saslHandler = {
+        getInitFrameContent: function (credentials) {
+          return new Promise(function (resolve) {
+            resolve({
+              mechanism: expectedSaslMechanism,
+              initialResponse: expectedInitialAnswer
+            });
+          });
+        },
+        getChallengeResponseContent: function (challenge) {
+          expect(challenge[0].value.toString()).to.equal(expectedChallenge.toString());
+          return new Promise(function (resolve) {
+            resolve(expectedChallengeResponse);
+          });
+        }
+      };
+
+      server = new MockServer();
+      server.setSequence([
+        constants.saslVersion,
+        expectedSaslInitFrame,
+        expectedSaslChallengeResponseFrame,
+        constants.amqpVersion,
+        new frames.OpenFrame(test.policy.connect.options),
+        new frames.CloseFrame()
+      ], [
+        constants.saslVersion,
+        [ true, new frames.SaslMechanismsFrame({ saslServerMechanisms: [expectedSaslMechanism] }) ],
+        new frames.SaslChallengeFrame({
+          challenge: expectedChallenge
+        }),
+        new frames.SaslOutcomeFrame({ code: constants.saslOutcomes.ok }),
+        constants.amqpVersion,
+        new frames.OpenFrame(test.policy.connect.options),
+        [ true,
+          new frames.CloseFrame({
+            error: { condition: ErrorCondition.ConnectionForced, description: 'test' }
+          })
+        ]
+      ]);
+
+      var connection = new Connection(test.policy.connect);
+      server.setup(connection);
+
+
+      var expected = [
+        'DISCONNECTED', 'START', 'IN_SASL', 'HDR_SENT', 'HDR_EXCH',
+        'OPEN_SENT', 'OPENED', 'CLOSE_RCVD', 'DISCONNECTED'
+      ];
+
+      connection.connSM.bind(tu.assertTransitions(expected, function() { done(); }));
+      connection.open({protocol: 'amqp', host: 'localhost', port: server.port}, new Sasl('TEST', saslHandler));
     });
   });
 });

--- a/test/unit/test_sasl_anonymous.js
+++ b/test/unit/test_sasl_anonymous.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var SaslAnonymous = require('../../lib/sasl/sasl_anonymous'),
+    expect = require('chai').expect;
+
+describe('SaslAnonymous', function () {
+  describe('getInitFrameContent', function () {
+    it('should return a well formed content object', function (done) {
+      var saslHandler = new SaslAnonymous();
+      saslHandler.getInitFrameContent().then(function (initContent) {
+        expect(initContent.mechanism).to.equal('ANONYMOUS');
+        expect(initContent.initialResponse).to.be.instanceOf(Buffer);
+        expect(initContent.initialResponse.length).to.equal(1);
+        expect(initContent.initialResponse[0]).to.equal(0);
+        done();
+      });
+    });
+  });
+
+  describe('getChallengeResponse', function () {
+    it('should return undefined', function (done) {
+      var saslHandler = new SaslAnonymous();
+      saslHandler.getChallengeResponseContent().then(function (response) {
+        expect(response).to.equal(undefined);
+        done();
+      });
+    });
+  });
+});

--- a/test/unit/test_sasl_plain.js
+++ b/test/unit/test_sasl_plain.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var builder = require('buffer-builder'),
+    SaslPlain = require('../../lib/sasl/sasl_plain'),
+
+    tu = require('./../testing_utils'),
+    expect = require('chai').expect;
+
+describe('SaslPlain', function () {
+  describe('getInitFrameContent', function () {
+    it('should return a well formed content object', function (done) {
+      var saslHandler = new SaslPlain();
+      saslHandler.getInitFrameContent({ user: 'user', pass: 'pass' }).then(function (initContent) {
+        expect(initContent.mechanism).to.equal('PLAIN');
+        var expectedBuffer = tu.buildBuffer([0, builder.prototype.appendString, 'user', 0, builder.prototype.appendString, 'pass']);
+        for(var i = 0; i < expectedBuffer.length; i++) {
+          expect(initContent.initialResponse[i]).to.equal(expectedBuffer[i]);
+        }
+        done();
+      });
+    });
+  });
+
+  describe('getChallengeResponse', function () {
+    it('should return undefined', function (done) {
+      var saslHandler = new SaslPlain();
+      saslHandler.getChallengeResponseContent().then(function (response) {
+        expect(response).to.equal(undefined);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds the ability to "inject" a SASL mechanism and associated handler in the library, which effectively unlocks the ability to have complex SASL challenge/response exchanges.

- moved sasl-anonymous and and sasl-plain logic within their own handlers (classes)
- modified client & connection to enable injecting a handler in the main sasl logic
- added a client API (`registerSaslMechanism`) to enable the user to inject their own sasl handler.