### PR TITLE
fix(session): clear session states between reconnections

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -518,10 +518,17 @@ AMQPClient.prototype._clearConnectionState = function(saveReconnectDetails) {
     this._reconnect = null;
   }
 
-  if (this._session) this._session._resetLinkState();
+  if (this._session) {
+    this._session.removeAllListeners();
+    this._session._resetLinkState();
+  }
   this._userSessions.forEach(function (session) {
+    session.removeAllListeners();
     session._resetLinkState();
   });
+
+  this._session = null;
+  this._userSessions = [];
 };
 
 // Helper methods for mocking in tests.

--- a/lib/session.js
+++ b/lib/session.js
@@ -203,7 +203,7 @@ Session.prototype.createLink = function(linkPolicy) {
   var self = this;
   link.on(Link.Detached, function(details) {
     debug('detached(' + link.name + '): ' + (details ? details.error : 'No details'));
-    if (!link.shouldReattach() || self.disposed) self._removeLink(link);
+    if (!link.shouldReattach() || self._disposed) self._removeLink(link);
   });
 
   link.on(Link.ErrorReceived, function(err) {
@@ -477,9 +477,9 @@ Session.prototype._processDispositionFrame = function(frame) {
  */
 Session.prototype._resetLinkState = function() {
   var self = this;
-  var forceDetachLink = function(l) { 
+  var forceDetachLink = function(l) {
     l.forceDetach();
-    if (self.disposed) self._removeLink(l);
+    if (self._disposed) self._removeLink(l);
   };
   u.values(this._senderLinks).forEach(forceDetachLink);
   u.values(this._receiverLinks).forEach(forceDetachLink);


### PR DESCRIPTION
Here's a (blunt) suggestion on how to clean sessions between reconnections - I'm not sure in which circumstances it's desirable to keep a session over multiple reconnections.

Without this some tests start failing with IoT Hub when trying to reattach links over "persisted" sessions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/352)
<!-- Reviewable:end -->
