### PR TITLE
fix(session): disable reestablish on disconnect and guard against duplicate begin() calls

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -18,16 +18,50 @@ var EventEmitter = require('events').EventEmitter,
     Connection = require('./connection');
 
 var stateMachine = function(session) {
+  function warnBeginState(state) {
+    console.warn('BUG: Tried to call begin() on a session in nonterminal state ' + state);
+  }
+
   return {
-    'UNMAPPED': { sendBegin: 'BEGIN_SENT' },
-    'BEGIN_SENT': { beginReceived: 'MAPPED' },
+    'UNMAPPED': {
+      begin: function(sessionPolicy) {
+        session._performBegin(sessionPolicy);
+        return this.BEGIN_SENT;
+      }
+    },
+    'BEGIN_SENT': {
+      beginReceived: 'MAPPED',
+      disconnected: 'UNMAPPED',
+      begin: function(sessionPolicy) {
+        warnBeginState('BEGIN_SENT');
+      }
+    },
     'MAPPED': {
       sendEnd: 'END_SENT',
-      endReceived: 'END_RCVD'
+      endReceived: 'END_RCVD',
+      disconnected: 'UNMAPPED'
     },
-    'END_SENT': { endReceived: 'UNMAPPED' },
-    'DISCARDING': { endReceived: 'UNMAPPED' },
-    'END_RCVD': { sendEnd: 'UNMAPPED' }
+    'END_SENT': {
+      endReceived: 'UNMAPPED',
+      disconnected: 'UNMAPPED',
+      begin: function(sessionPolicy) {
+        warnBeginState('END_SENT');
+      }
+    },
+    'DISCARDING': {
+      endReceived: 'UNMAPPED',
+      disconnected: 'UNMAPPED',
+      begin: function(sessionPolicy) {
+        warnBeginState('DISCARDING');
+      }
+    },
+    'END_RCVD': {
+      sendEnd: 'UNMAPPED',
+      disconnected: 'UNMAPPED',
+      begin: function(sessionPolicy) {
+        warnBeginState('END_RCVD');
+      }
+    }
   };
 };
 
@@ -158,6 +192,13 @@ Object.defineProperty(Session.prototype, 'disposed', {
 });
 
 Session.prototype.begin = function(sessionPolicy) {
+  this.sm.begin(sessionPolicy);
+};
+
+Session.prototype._performBegin = function(sessionPolicy) {
+  // The session is considered new at this point
+  this._disposed = false;
+
   var sessionParams = u.deepCopy(sessionPolicy.options);
   u.assertArguments(sessionParams, ['nextOutgoingId', 'incomingWindow', 'outgoingWindow']);
 
@@ -170,11 +211,14 @@ Session.prototype.begin = function(sessionPolicy) {
   this._sessionParams = sessionParams;
   this._initialOutgoingId = sessionParams.nextOutgoingId;
 
-  this.sm.sendBegin();
   var self = this;
   this._processFrameEH = function(frame) { self._processFrame(frame); };
   this.connection.on(Connection.FrameReceived, this._processFrameEH);
-  this.connection.on(Connection.Disconnected, this._resetLinkState);
+  this.connection.on(Connection.Disconnected, function() {
+    debug('unmapping due to disconnection');
+    self.sm.disconnected();
+    self._resetLinkState();
+  });
 
   var beginFrame = new frames.BeginFrame(this._sessionParams);
   beginFrame.channel = this.channel;
@@ -203,7 +247,7 @@ Session.prototype.createLink = function(linkPolicy) {
   var self = this;
   link.on(Link.Detached, function(details) {
     debug('detached(' + link.name + '): ' + (details ? details.error : 'No details'));
-    if (!link.shouldReattach() || self.disposed) self._removeLink(link);
+    if (!link.shouldReattach() || self._disposed) self._removeLink(link);
   });
 
   link.on(Link.ErrorReceived, function(err) {
@@ -479,7 +523,7 @@ Session.prototype._resetLinkState = function() {
   var self = this;
   var forceDetachLink = function(l) { 
     l.forceDetach();
-    if (self.disposed) self._removeLink(l);
+    if (self._disposed) self._removeLink(l);
   };
   u.values(this._senderLinks).forEach(forceDetachLink);
   u.values(this._receiverLinks).forEach(forceDetachLink);
@@ -496,7 +540,7 @@ Session.prototype._attemptReestablish = function() {
 
   var self = this;
   this._reestablishTimer = setTimeout(function() {
-    if (self._shouldReestablish() && self.connection.connected) {
+    if (self._shouldReestablish() && self.sm.getMachineState() === 'UNMAPPED' && self.connection.connected) {
       debug('attempting to re-establish session');
       self.begin(self.policy);
     } else {


### PR DESCRIPTION
With `reestablish` enabled for sessions, the session can end up in a state where it is trying to reestablish itself while the connection is trying to do the same, leading to duplicate calls to `begin()`. The following has been changed to better handle this situation and others like it:

 * Disable the `begin()` attempt (and any further retries) if the link isn't still `UNMAPPED`. We already handle if the connection is broken, but this handles the connection coming down and back up (with a corresponding `begin()` call) while we're waiting to retry.
 * Guard against initializing a session multiple times. Since `begin()` isn't idempotent, calling it on a session that is already active with attached links will cause a second session to be established and the links to be implicitly assigned to that session without the server being informed. We now do nothing if the session is already active and throw if it's in a transition state.
 * Unmap a session if its connection is disconnected. This was already being done implicitly, but the state machine wasn't actually updating to the new state, which was erroneously tripping the state check in `begin()`. The `disconnected()` transition has been added to the state machine to take care of this. For reference, the AMQP 1.0 spec states that "Sessions end automatically when the Connection is closed or interrupted.", so this behavior is consistent with the specification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/353)
<!-- Reviewable:end -->
